### PR TITLE
WIP: Add CLI command for feed generation

### DIFF
--- a/src/API/Controllers/ApiController.php
+++ b/src/API/Controllers/ApiController.php
@@ -120,10 +120,8 @@ class ApiController {
 		try {
 			$feed = new JsonFileFeed();
 
-			$feed->start();
 			$product_walker = new ProductWalker( $this->product_mapper, $this->feed_validator, $feed );
 			$product_walker->walk();
-			$feed->end();
 
 			$response = rest_ensure_response( $feed->deliver() );
 			$response->header( 'Content-Type', 'application/json; charset=utf-8' );

--- a/src/Admin/Controllers/AdminController.php
+++ b/src/Admin/Controllers/AdminController.php
@@ -58,20 +58,19 @@ class AdminController {
 	/**
 	 * Dependencies injector.
 	 *
-	 * @param SettingsRepository $settings The settings repository.
-	 * @param FeedValidator      $validator The validator.
-	 * @param ProductMapper      $product_mapper The product mapper.
+	 * @param FeedValidator       $validator The validator.
+	 * @param ProductMapper       $product_mapper The product mapper.
+	 * @param CredentialValidator $credential_validator The credential validator.
 	 */
 	public function init(
-		SettingsRepository $settings,
 		FeedValidator $validator,
-		ProductMapper $product_mapper
+		ProductMapper $product_mapper,
+		CredentialValidator $credential_validator
 	) {
-		$this->validator      = $validator;
-		$this->product_mapper = $product_mapper;
-		$this->logger         = function_exists( 'wc_get_logger' ) ? wc_get_logger() : null;
-
-		$this->credential_validator = new CredentialValidator( $settings );
+		$this->validator            = $validator;
+		$this->product_mapper       = $product_mapper;
+		$this->logger               = function_exists( 'wc_get_logger' ) ? wc_get_logger() : null;
+		$this->credential_validator = $credential_validator;
 	}
 
 	/**

--- a/src/Admin/Controllers/AdminController.php
+++ b/src/Admin/Controllers/AdminController.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\ProductFeedForOpenAI\Admin\Controllers;
 
-use Automattic\WooCommerce\ProductFeedForOpenAI\Settings\SettingsRepository;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Platforms\OpenAI\FeedValidator;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Admin\Helpers\CredentialValidator;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\ProductMapperInterface;

--- a/src/Admin/Helpers/CredentialValidator.php
+++ b/src/Admin/Helpers/CredentialValidator.php
@@ -19,7 +19,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Validates credentials and configuration for feed delivery.
  */
 class CredentialValidator {
-
 	/**
 	 * Settings repository instance.
 	 *
@@ -28,11 +27,11 @@ class CredentialValidator {
 	private SettingsRepository $settings;
 
 	/**
-	 * Constructor.
+	 * Dependency injector.
 	 *
 	 * @param SettingsRepository $settings The settings repository.
 	 */
-	public function __construct( SettingsRepository $settings ) {
+	public function init( SettingsRepository $settings ) {
 		$this->settings = $settings;
 	}
 

--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -14,6 +14,7 @@ use WP_CLI_Command;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\FeedValidatorInterface;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\ProductMapperInterface;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\ProductWalker;
+use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\WalkerProgress;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Platforms\OpenAI\FeedValidator;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Platforms\OpenAI\ProductMapper;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Storage\JsonFileFeed;
@@ -81,10 +82,12 @@ class Command extends WP_CLI_Command {
 	 * @param array $assoc_args Associative arguments.
 	 */
 	public function generate( $args, $assoc_args ) {
+		// Read args and prepare defaults.
 		$timeout    = (int) $assoc_args['timeout'];
 		$batch_size = (int) $assoc_args['batch-size'];
 		$silent     = (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'silent', false );
 
+		// Initialize the feed and walker, set them up.
 		$feed   = new JsonFileFeed();
 		$walker = new ProductWalker( $this->product_mapper, $this->validator, $feed );
 		$walker->set_batch_size( $batch_size );
@@ -95,12 +98,12 @@ class Command extends WP_CLI_Command {
 		}
 
 		$walker->walk(
-			function ( $processed, $page, $pages ) use ( $silent ) {
+			function ( WalkerProgress $progress ) use ( $silent ) {
 				if ( $silent ) {
 					return;
 				}
 
-				WP_CLI::log( "Batch $page/$pages: Processed $processed products" );
+				WP_CLI::log( "Batch $progress->processed_batches/$progress->total_batch_count: Processed $progress->processed_items/$progress->total_count products" );
 			}
 		);
 

--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\ProductFeedForOpenAI\CLI;
 
+use Automattic\WooCommerce\ProductFeedForOpenAI\Admin\Helpers\CredentialValidator;
 use WP_CLI;
 use WP_CLI_Command;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\FeedValidatorInterface;
@@ -38,17 +39,27 @@ class Command extends WP_CLI_Command {
 	private FeedValidatorInterface $validator;
 
 	/**
+	 * Credential validator instance.
+	 *
+	 * @var CredentialValidator
+	 */
+	private CredentialValidator $credential_validator;
+
+	/**
 	 * Dependency injector.
 	 *
-	 * @param ProductMapper $product_mapper The product mapper.
-	 * @param FeedValidator $validator The feed validator.
+	 * @param ProductMapper       $product_mapper The product mapper.
+	 * @param FeedValidator       $validator The feed validator.
+	 * @param CredentialValidator $credential_validator The credential validator.
 	 */
 	public function init(
 		ProductMapper $product_mapper,
-		FeedValidator $validator
+		FeedValidator $validator,
+		CredentialValidator $credential_validator
 	) {
-		$this->product_mapper = $product_mapper;
-		$this->validator      = $validator;
+		$this->product_mapper       = $product_mapper;
+		$this->validator            = $validator;
+		$this->credential_validator = $credential_validator;
 	}
 
 	/**
@@ -74,6 +85,12 @@ class Command extends WP_CLI_Command {
 	 * default: false
 	 * ---
 	 *
+	 * [--send]
+	 * : Whether to send the feed to an API.
+	 * ---
+	 * default: false
+	 * ---
+	 *
 	 * ## EXAMPLES
 	 *    wp product-feed generate
 	 *    wp product-feed generate --timeout=200
@@ -86,6 +103,22 @@ class Command extends WP_CLI_Command {
 		$timeout    = (int) $assoc_args['timeout'];
 		$batch_size = (int) $assoc_args['batch-size'];
 		$silent     = (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'silent', false );
+		$send       = (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'send', false );
+
+		// Verify settings in advance if there is a requirement to send the feed.
+		if ( $send ) {
+			$endpoint = $this->credential_validator->get_endpoint_url();
+			if ( empty( $endpoint ) ) {
+				return WP_CLI::error( 'Endpoint URL is not configured. Aborting.' );
+			}
+
+			$token = $this->credential_validator->get_auth_token();
+			if ( ! empty( $token ) ) {
+				$headers = [
+					'Authorization' => 'Bearer ' . $token,
+				];
+			}
+		}
 
 		// Initialize the feed and walker, set them up.
 		$feed   = new JsonFileFeed();
@@ -108,12 +141,36 @@ class Command extends WP_CLI_Command {
 		);
 
 		$path = $feed->get_file_path();
-		if ( $silent ) {
+		if ( $silent && ! $send ) {
 			WP_CLI::out( $path );
 			return;
 		}
 
-		WP_CLI::success( 'Feed generated successfully' );
-		WP_CLI::log( "Path: $path" );
+		if ( ! $silent ) {
+			WP_CLI::success( 'Feed generated successfully' );
+			WP_CLI::log( "Path: $path" );
+
+			if ( ! $send ) {
+				WP_CLI::log( 'The --send option was not provided, the feed has not been sent.' );
+				return;
+			}
+
+			WP_CLI::log( 'Sending feed to API...' );
+		}
+
+		// Add the needed additional headers.
+		$headers['Content-Type'] = 'application/json';
+
+		$response = wp_remote_post(
+			$endpoint,
+			[
+				'headers' => $headers,
+				'timeout' => 30,
+				'body'    => wp_json_encode( $feed->deliver() ),
+			]
+		);
+
+		// No need to do wonders with the response, just print it.
+		WP_CLI::print_value( $response );
 	}
 }

--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * CLI Command class.
+ *
+ * @package Automattic\WooCommerce\ProductFeedForOpenAI
+ */
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\ProductFeedForOpenAI\CLI;
+
+use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\FeedValidatorInterface;
+use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\ProductMapperInterface;
+use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\ProductWalker;
+use Automattic\WooCommerce\ProductFeedForOpenAI\Platforms\OpenAI\FeedValidator;
+use Automattic\WooCommerce\ProductFeedForOpenAI\Platforms\OpenAI\ProductMapper;
+use Automattic\WooCommerce\ProductFeedForOpenAI\Storage\JsonInMemoryFeed;
+
+/**
+ * CLI command for generating a product feed.
+ */
+class Command extends \WP_CLI_Command {
+	/**
+	 * Product mapper instance.
+	 *
+	 * @var ProductMapperInterface
+	 */
+	private ProductMapperInterface $product_mapper;
+
+	/**
+	 * Feed validator instance.
+	 *
+	 * @var FeedValidatorInterface
+	 */
+	private FeedValidatorInterface $validator;
+
+	/**
+	 * Dependency injector.
+	 *
+	 * @param ProductMapper $product_mapper The product mapper.
+	 * @param FeedValidator $validator The feed validator.
+	 */
+	public function init(
+		ProductMapper $product_mapper,
+		FeedValidator $validator
+	) {
+		$this->product_mapper = $product_mapper;
+		$this->validator      = $validator;
+	}
+
+	/**
+	 * Generates a product feed.
+	 *
+	 * ## EXAMPLES
+	 *    wp product-feed generate
+	 */
+	public function generate() {
+		$feed   = new JsonInMemoryFeed();
+		$walker = new ProductWalker( $this->product_mapper, $this->validator, $feed );
+		$walker->walk( 300 );
+
+		\WP_CLI::success( wp_json_encode( $feed->deliver() ) );
+	}
+}

--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -9,17 +9,19 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\ProductFeedForOpenAI\CLI;
 
+use WP_CLI;
+use WP_CLI_Command;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\FeedValidatorInterface;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\ProductMapperInterface;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\ProductWalker;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Platforms\OpenAI\FeedValidator;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Platforms\OpenAI\ProductMapper;
-use Automattic\WooCommerce\ProductFeedForOpenAI\Storage\JsonInMemoryFeed;
+use Automattic\WooCommerce\ProductFeedForOpenAI\Storage\JsonFileFeed;
 
 /**
  * CLI command for generating a product feed.
  */
-class Command extends \WP_CLI_Command {
+class Command extends WP_CLI_Command {
 	/**
 	 * Product mapper instance.
 	 *
@@ -51,14 +53,60 @@ class Command extends \WP_CLI_Command {
 	/**
 	 * Generates a product feed.
 	 *
+	 * ## OPTIONS
+	 *
+	 * [--timeout=<seconds>]
+	 * : The number of seconds to extend the execution time limit per batch.
+	 * ---
+	 * default: 300
+	 * ---
+	 *
+	 * [--batch-size=<number>]
+	 * : The number of products to process per batch.
+	 * ---
+	 * default: 100
+	 * ---
+	 *
+	 * [--silent]
+	 * : Whether to suppress informational messages.
+	 * ---
+	 * default: false
+	 * ---
+	 *
 	 * ## EXAMPLES
 	 *    wp product-feed generate
+	 *    wp product-feed generate --timeout=200
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Associative arguments.
 	 */
-	public function generate() {
-		$feed   = new JsonInMemoryFeed();
-		$walker = new ProductWalker( $this->product_mapper, $this->validator, $feed );
-		$walker->walk( 300 );
+	public function generate( $args, $assoc_args ) {
+		$timeout    = (int) $assoc_args['timeout'];
+		$batch_size = (int) $assoc_args['batch-size'];
+		$silent     = (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'silent', false );
 
-		\WP_CLI::success( wp_json_encode( $feed->deliver() ) );
+		$feed   = new JsonFileFeed();
+		$walker = new ProductWalker( $this->product_mapper, $this->validator, $feed );
+		$walker->set_batch_size( $batch_size );
+		$walker->add_time_limit( $timeout );
+
+		if ( ! $silent ) {
+			WP_CLI::log( 'Starting feed generation...' );
+		}
+
+		$walker->walk(
+			function ( $processed, $page, $pages ) {
+				WP_CLI::log( "Batch $page/$pages: Processed $processed products" );
+			}
+		);
+
+		$path = $feed->get_file_path();
+		if ( $silent ) {
+			WP_CLI::out( $path );
+			return;
+		}
+
+		WP_CLI::success( 'Feed generated successfully' );
+		WP_CLI::log( "Path: $path" );
 	}
 }

--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -95,7 +95,11 @@ class Command extends WP_CLI_Command {
 		}
 
 		$walker->walk(
-			function ( $processed, $page, $pages ) {
+			function ( $processed, $page, $pages ) use ( $silent ) {
+				if ( $silent ) {
+					return;
+				}
+
 				WP_CLI::log( "Batch $page/$pages: Processed $processed products" );
 			}
 		);

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -12,6 +12,7 @@ namespace Automattic\WooCommerce\ProductFeedForOpenAI\Core;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Admin\Controllers\AdminController;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Admin\Controllers\ProductFieldsController;
 use Automattic\WooCommerce\ProductFeedForOpenAI\API\Controllers\ApiController;
+use Automattic\WooCommerce\ProductFeedForOpenAI\CLI\Command;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Platforms\OpenAI\AgenticIntegration;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Core\DependencyManagement\Container;
 
@@ -81,6 +82,11 @@ final class Plugin {
 		// Initialize components on WordPress init hook.
 		add_action( 'init', [ $this, 'init' ], 0 );
 
+		// Register the CLI command as well.
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			add_action( 'cli_init', [ $this, 'register_cli_commands' ] );
+		}
+
 		$this->initialized = true;
 	}
 
@@ -97,6 +103,21 @@ final class Plugin {
 		$this->container->get( ProductFieldsController::class )->initialize();
 
 		$this->container->get( ApiController::class )->initialize();
+	}
+
+	/**
+	 * Register WP-CLI commands.
+	 */
+	public function register_cli_commands(): void {
+		$command = $this->container->get( Command::class );
+		\WP_CLI::add_command( 'product-feed', $command );
+	}
+
+	/**
+	 * WP-CLI command to generate product feed
+	 */
+	public function cli_generate_feed(): void {
+		echo 'Hello!';
 	}
 
 	/**

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -114,13 +114,6 @@ final class Plugin {
 	}
 
 	/**
-	 * WP-CLI command to generate product feed
-	 */
-	public function cli_generate_feed(): void {
-		echo 'Hello!';
-	}
-
-	/**
 	 * Plugin activation
 	 */
 	public function activate(): void {

--- a/src/Feed/ProductWalker.php
+++ b/src/Feed/ProductWalker.php
@@ -60,9 +60,10 @@ class ProductWalker {
 	/**
 	 * Walks through all products.
 	 *
+	 * @param int $extend_execution_time_limit The number of seconds to extend the execution time limit per batch.
 	 * @return int The total number of products walked through.
 	 */
-	public function walk(): int {
+	public function walk( int $extend_execution_time_limit = 0 ): int {
 		$page     = 1;
 		$per_page = 100;
 		$total    = 0;
@@ -89,6 +90,10 @@ class ProductWalker {
 		do {
 			$iterated = $this->iterate( $args, $page, $per_page );
 			$total   += $iterated;
+
+			if ( $extend_execution_time_limit > 0 ) {
+				set_time_limit( $extend_execution_time_limit );
+			}
 		} while ( $iterated === $per_page );
 
 		return $total;

--- a/src/Feed/ProductWalker.php
+++ b/src/Feed/ProductWalker.php
@@ -39,6 +39,20 @@ class ProductWalker {
 	private $validator;
 
 	/**
+	 * The number of products to iterate through per batch.
+	 *
+	 * @var int
+	 */
+	private int $per_page = 100;
+
+	/**
+	 * The time limit to extend the execution time limit per batch.
+	 *
+	 * @var int
+	 */
+	private int $time_limit = 0;
+
+	/**
 	 * Class constructor.
 	 *
 	 * This class will not be available through DI. Instead, it needs to be instantiated directly.
@@ -58,15 +72,36 @@ class ProductWalker {
 	}
 
 	/**
+	 * Set the number of products to iterate through per batch.
+	 *
+	 * @param int $batch_size The number of products to iterate through per batch.
+	 * @return self
+	 */
+	public function set_batch_size( int $batch_size ): self {
+		$this->per_page = $batch_size;
+		return $this;
+	}
+
+	/**
+	 * Set the time limit to extend the execution time limit per batch.
+	 *
+	 * @param int $time_limit Time limit in seconds.
+	 * @return self
+	 */
+	public function add_time_limit( int $time_limit ): self {
+		$this->time_limit = $time_limit;
+		return $this;
+	}
+
+	/**
 	 * Walks through all products.
 	 *
-	 * @param int $extend_execution_time_limit The number of seconds to extend the execution time limit per batch.
-	 * @return int The total number of products walked through.
+	 * @param callable $callback The callback to call after each batch of products is processed.
+	 * @return int The total number of products processed.
 	 */
-	public function walk( int $extend_execution_time_limit = 0 ): int {
-		$page     = 1;
-		$per_page = 100;
-		$total    = 0;
+	public function walk( ?callable $callback = null ): int {
+		$page  = 0;
+		$total = 0;
 
 		/**
 		 * Allows the base arguments for querying products for product feeds to be changed.
@@ -87,14 +122,34 @@ class ProductWalker {
 			]
 		);
 
+		// Instruct the feed to start.
+		$this->feed->start();
+
+		// Expectations will be stored here.
+		$all_products_count = null;
+		$total_batch_number = null;
+
 		do {
-			$iterated = $this->iterate( $args, $page, $per_page );
+			$result   = $this->iterate( $args, ++$page, $this->per_page );
+			$iterated = count( $result->products );
 			$total   += $iterated;
 
-			if ( $extend_execution_time_limit > 0 ) {
-				set_time_limit( $extend_execution_time_limit );
+			if ( is_null( $all_products_count ) ) {
+				$all_products_count = $result->total;
+				$total_batch_number = $result->max_num_pages;
 			}
-		} while ( $iterated === $per_page );
+
+			if ( is_callable( $callback ) ) {
+				$callback( $iterated, $page, $total_batch_number, $all_products_count );
+			}
+
+			if ( $this->time_limit > 0 ) {
+				set_time_limit( $this->time_limit );
+			}
+		} while ( $iterated === $this->per_page );
+
+		// Instruct the feed to end.
+		$this->feed->end();
 
 		return $total;
 	}
@@ -105,18 +160,19 @@ class ProductWalker {
 	 * @param array $args The arguments to pass to wc_get_products().
 	 * @param int   $page The page number to iterate through.
 	 * @param int   $limit The maximum number of products to iterate through.
-	 * @return int The number of products iterated through.
+	 * @return object The result of the query.
 	 */
-	public function iterate( array $args = [], int $page = 1, int $limit = 100 ): int {
-		$products = wc_get_products(
+	private function iterate( array $args = [], int $page = 1, int $limit = 100 ): object {
+		$result = wc_get_products(
 			[
 				...$args,
-				'page'  => $page,
-				'limit' => $limit,
+				'page'     => $page,
+				'limit'    => $limit,
+				'paginate' => true,
 			]
 		);
 
-		foreach ( $products as $product ) {
+		foreach ( $result->products as $product ) {
 			$mapped_data = $this->mapper->map_product( $product );
 
 			if ( ! empty( $this->validator->validate_entry( $mapped_data, $product ) ) ) {
@@ -126,6 +182,6 @@ class ProductWalker {
 			$this->feed->add_entry( $mapped_data );
 		}
 
-		return count( $products );
+		return $result;
 	}
 }

--- a/src/Feed/ProductWalker.php
+++ b/src/Feed/ProductWalker.php
@@ -100,8 +100,7 @@ class ProductWalker {
 	 * @return int The total number of products processed.
 	 */
 	public function walk( ?callable $callback = null ): int {
-		$page  = 0;
-		$total = 0;
+		$progress = null;
 
 		/**
 		 * Allows the base arguments for querying products for product feeds to be changed.
@@ -125,22 +124,21 @@ class ProductWalker {
 		// Instruct the feed to start.
 		$this->feed->start();
 
-		// Expectations will be stored here.
-		$all_products_count = null;
-		$total_batch_number = null;
-
 		do {
-			$result   = $this->iterate( $args, ++$page, $this->per_page );
+			$result   = $this->iterate( $args, $progress ? $progress->processed_batches + 1 : 1, $this->per_page );
 			$iterated = count( $result->products );
-			$total   += $iterated;
 
-			if ( is_null( $all_products_count ) ) {
-				$all_products_count = $result->total;
-				$total_batch_number = $result->max_num_pages;
+			// Indicate progress.
+			if ( is_null( $progress ) ) {
+				$progress = WalkerProgress::from_wc_get_products_result( $result );
+			} else {
+				$progress = clone $progress;
 			}
+			$progress->processed_items += $iterated;
+			++$progress->processed_batches;
 
 			if ( is_callable( $callback ) ) {
-				$callback( $iterated, $page, $total_batch_number, $all_products_count );
+				$callback( $progress );
 			}
 
 			if ( $this->time_limit > 0 ) {
@@ -151,7 +149,7 @@ class ProductWalker {
 		// Instruct the feed to end.
 		$this->feed->end();
 
-		return $total;
+		return $progress->processed_items;
 	}
 
 	/**

--- a/src/Feed/WalkerProgress.php
+++ b/src/Feed/WalkerProgress.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Walker Progress class.
+ *
+ * @package Automattic\WooCommerce\ProductFeedForOpenAI
+ */
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\ProductFeedForOpenAI\Feed;
+
+/**
+ * Simple class that tracks/indicates the progress of a walker.
+ */
+class WalkerProgress {
+	/**
+	 * Total number of items to process.
+	 *
+	 * @var int
+	 */
+	public int $total_count;
+
+	/**
+	 * Total number of batches to process.
+	 *
+	 * @var int
+	 */
+	public int $total_batch_count;
+
+	/**
+	 * Number of items processed so far.
+	 *
+	 * @var int
+	 */
+	public int $processed_items = 0;
+
+	/**
+	 * Number of batches processed so far.
+	 *
+	 * @var int
+	 */
+	public int $processed_batches = 0;
+
+	/**
+	 * Creates a WalkerProgress instance from a WooCommerce products query result.
+	 *
+	 * @param object $result The result object from wc_get_products().
+	 * @return static
+	 */
+	public static function from_wc_get_products_result( object $result ): static {
+		$progress = new static();
+
+		$progress->total_count       = $result->total;
+		$progress->total_batch_count = $result->max_num_pages;
+		$progress->processed_items   = 0;
+		$progress->processed_batches = 0;
+
+		return $progress;
+	}
+}

--- a/src/Storage/JsonFileFeed.php
+++ b/src/Storage/JsonFileFeed.php
@@ -95,12 +95,23 @@ class JsonFileFeed implements FeedInterface {
 	}
 
 	/**
-	 * Deliver the feed.
+	 * Deliver the feed and delete the temporary file.
 	 *
 	 * @return array An array that will be provided to WP_REST_Response.
 	 */
 	public function deliver(): array {
 		// Temporary. Will be changed once we support multiple formats.
-		return json_decode( file_get_contents( $this->file_path ), true );
+		$data = json_decode( file_get_contents( $this->file_path ), true );
+		unlink( $this->file_path );
+		return $data;
+	}
+
+	/**
+	 * Get the path to the feed file.
+	 *
+	 * @return string The path to the feed file.
+	 */
+	public function get_file_path(): string {
+		return $this->file_path;
 	}
 }


### PR DESCRIPTION
## Description

Adds a CLI command to generate the feed, together with some goodies that allow it to look meaningful.

There is also the opportunity to send the feed.

### In the next PRs

- Allow the CLI command to work with different providers, abstracting how they are loaded for other areas as well.
- Read and stream the file in chunks.

# Testing instructions

I'm using my WooPayments client directory for this and running:

```bash
npm run cli --silent "wp product-feed generate --batch-size=10 --debug=E_ALL"
```

Result:
<img width="569" height="142" alt="image" src="https://github.com/user-attachments/assets/10221dcc-7ca2-474a-8e15-e5c06f4ff7a7" />

Next one just outputs the file name:

```bash
npm run cli --silent "wp product-feed generate --batch-size=10 --silent --debug=E_ALL"
```

Do not forget to test the `--send` flag!

## Checklist

<!-- Mark completed items with an "x" -->

- [x] `npm run test:php` does not return errors.
- [x] `npm run lint:php` does not return errors.
