### PR TITLE
Simplify specific OpenAI fields in product editor

### DIFF
--- a/openai-product-feed-for-woo.php
+++ b/openai-product-feed-for-woo.php
@@ -14,8 +14,8 @@
  * Text Domain:          woocommerce-product-feed-openai
  * Requires at least:    6.0
  * Requires PHP:         7.4
- * WC requires at least: 7.0
- * WC tested up to:      9.6
+ * WC requires at least: 9.1.0
+ * WC tested up to:      10.3.0
  */
 
 declare(strict_types=1);

--- a/src/API/Controllers/ApiController.php
+++ b/src/API/Controllers/ApiController.php
@@ -114,14 +114,21 @@ class ApiController {
 	/**
 	 * Handle preview feed request
 	 *
+	 * @param \WP_REST_Request $request Request object.
 	 * @return \WP_REST_Response|\WP_Error Response object or error.
 	 */
-	public function handle_preview_feed() {
+	public function handle_preview_feed( \WP_REST_Request $request ) {
 		try {
 			$feed = new JsonFileFeed();
 
 			$product_walker = new ProductWalker( $this->product_mapper, $this->feed_validator, $feed );
-			$product_walker->walk();
+
+			$additional_args = [];
+			if ( $request->get_param( 'product_id' ) ) {
+				$additional_args['include'] = [ $request->get_param( 'product_id' ) ];
+			}
+
+			$product_walker->walk( null, $additional_args );
 
 			return rest_ensure_response( $feed->deliver() );
 		} catch ( \Exception $e ) {

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Automattic\WooCommerce\ProductFeedForOpenAI\Core;
 
 use Automattic\WooCommerce\ProductFeedForOpenAI\Admin\Controllers\AdminController;
-use Automattic\WooCommerce\ProductFeedForOpenAI\Admin\Controllers\ProductFieldsController;
+use Automattic\WooCommerce\ProductFeedForOpenAI\Platforms\OpenAI\ProductFieldsController;
 use Automattic\WooCommerce\ProductFeedForOpenAI\API\Controllers\ApiController;
 use Automattic\WooCommerce\ProductFeedForOpenAI\CLI\Command;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Platforms\OpenAI\AgenticIntegration;

--- a/src/Feed/ProductWalker.php
+++ b/src/Feed/ProductWalker.php
@@ -97,9 +97,10 @@ class ProductWalker {
 	 * Walks through all products.
 	 *
 	 * @param callable $callback The callback to call after each batch of products is processed.
+	 * @param array    $additional_args Optional. Additional arguments to merge into the base query args.
 	 * @return int The total number of products processed.
 	 */
-	public function walk( ?callable $callback = null ): int {
+	public function walk( ?callable $callback = null, array $additional_args = [] ): int {
 		$progress = null;
 
 		/**
@@ -114,11 +115,14 @@ class ProductWalker {
 		 */
 		$args = apply_filters(
 			'wpfoai_product_feed_args',
-			[
-				'status' => [ 'publish' ],
-				'type'   => [ 'simple', 'variation' ],
-				'return' => 'objects',
-			]
+			array_merge(
+				[
+					'status' => [ 'publish' ],
+					'type'   => [ 'simple', 'variation' ],
+					'return' => 'objects',
+				],
+				$additional_args
+			)
 		);
 
 		// Instruct the feed to start.

--- a/src/Platforms/OpenAI/FeedSchema.php
+++ b/src/Platforms/OpenAI/FeedSchema.php
@@ -145,6 +145,17 @@ class FeedSchema {
 				'type'        => 'string',
 				'description' => 'Combined dimensions (LxWxH unit)',
 			],
+			'related_product_id'        => [
+				'required'    => false,
+				'type'        => 'string',
+				'description' => 'Comma-separated list of related product IDs',
+			],
+			'relationship_type'         => [
+				'required'    => false,
+				'type'        => 'enum',
+				'values'      => [ 'part_of_set', 'required_part', 'often_bought_with', 'substitute', 'different_brand', 'accessory' ],
+				'description' => 'Relationship type',
+			],
 
 			// Media.
 			'image_link'                => [

--- a/src/Platforms/OpenAI/ProductFieldsController.php
+++ b/src/Platforms/OpenAI/ProductFieldsController.php
@@ -16,10 +16,28 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Handles WooCommerce product data tab for OpenAI feed attributes
  *
- * Adds custom product fields for OpenAI feed data that can't be automatically
- * derived from WooCommerce's existing product data structure.
  */
 class ProductFieldsController {
+
+	/**
+	 * Meta key for Manufacturer Part Number (MPN)
+	 */
+	public const KEY_MPN = '_wpfoai_mpn';
+
+	/**
+	 * Meta key for product condition
+	 */
+	public const KEY_CONDITION = '_wpfoai_condition';
+
+	/**
+	 * Meta key for disabling product in search
+	 */
+	public const KEY_DISABLE_SEARCH = '_wpfoai_disable_search';
+
+	/**
+	 * Meta key for disabling product in checkout
+	 */
+	public const KEY_DISABLE_CHECKOUT = '_wpfoai_disable_checkout';
 
 	/**
 	 * Initialize product fields functionality
@@ -50,344 +68,9 @@ class ProductFieldsController {
 
 	/**
 	 * Render the OpenAI Feed product data panel
-	 *
-	 * Displays custom fields for OpenAI feed attributes in the WooCommerce product editor.
 	 */
 	public function render_product_data_panel(): void {
-		echo '<div id="wpfoai_product_data" class="panel woocommerce_options_panel hidden">';
-
-		$product = function_exists( 'wc_get_product' ) ? wc_get_product( get_the_ID() ) : null;
-
-		echo '<p class="description">' . esc_html__( 'These fields inherit from WooCommerce global settings and existing product data (title, pricing, attributes). Set a value here only if you want to override the inherited value.', 'woocommerce-product-feed-openai' ) . '</p>';
-		echo '<div class="options_group">';
-
-		woocommerce_wp_text_input(
-			[
-				'id'          => '_gtin',
-				'label'       => __( 'GTIN', 'woocommerce-product-feed-openai' ),
-				'desc_tip'    => true,
-				'description' => __( 'Global Trade Item Number (GTIN, UPC, EAN, etc.)', 'woocommerce-product-feed-openai' ),
-			]
-		);
-
-		woocommerce_wp_text_input(
-			[
-				'id'          => '_mpn',
-				'label'       => __( 'MPN', 'woocommerce-product-feed-openai' ),
-				'desc_tip'    => true,
-				'description' => __( 'Required if GTIN is not provided.', 'woocommerce-product-feed-openai' ),
-			]
-		);
-
-		woocommerce_wp_text_input(
-			[
-				'id'          => '_brand',
-				'label'       => __( 'Brand (fallback)', 'woocommerce-product-feed-openai' ),
-				'desc_tip'    => true,
-				'description' => __( 'Used if attribute pa_brand is not set.', 'woocommerce-product-feed-openai' ),
-				'placeholder' => $this->get_attribute_placeholder( $product, 'pa_brand' ),
-			]
-		);
-
-		echo '</div><div class="options_group">';
-
-		woocommerce_wp_checkbox(
-			[
-				'id'          => '_wpfoai_disable_search',
-				'value'       => get_post_meta( get_the_ID(), '_wpfoai_disable_search', true ) === 'yes' ? 'yes' : 'no',
-				'label'       => __( 'Disable search (ChatGPT)', 'woocommerce-product-feed-openai' ),
-				'description' => __( 'Overrides global default for this product.', 'woocommerce-product-feed-openai' ),
-			]
-		);
-
-		woocommerce_wp_checkbox(
-			[
-				'id'          => '_wpfoai_disable_checkout',
-				'value'       => get_post_meta( get_the_ID(), '_wpfoai_disable_checkout', true ) === 'yes' ? 'yes' : 'no',
-				'label'       => __( 'Disable checkout (ChatGPT)', 'woocommerce-product-feed-openai' ),
-				'description' => __( 'Requires search to be enabled.', 'woocommerce-product-feed-openai' ),
-			]
-		);
-
-		echo '</div><div class="options_group">';
-
-		woocommerce_wp_text_input(
-			[
-				'id'          => '_wpfoai_material',
-				'label'       => __( 'Material', 'woocommerce-product-feed-openai' ),
-				'description' => __( 'Primary material (e.g., cotton, plastic, metal)', 'woocommerce-product-feed-openai' ),
-			]
-		);
-
-		woocommerce_wp_select(
-			[
-				'id'          => '_wpfoai_condition',
-				'label'       => __( 'Condition', 'woocommerce-product-feed-openai' ),
-				'options'     => [
-					''            => __( '— Select —', 'woocommerce-product-feed-openai' ),
-					'new'         => 'new',
-					'refurbished' => 'refurbished',
-					'used'        => 'used',
-				],
-				'description' => __( 'Required if not new.', 'woocommerce-product-feed-openai' ),
-			]
-		);
-
-		woocommerce_wp_select(
-			[
-				'id'          => '_wpfoai_age_group',
-				'label'       => __( 'Age group', 'woocommerce-product-feed-openai' ),
-				'options'     => [
-					''        => __( '— Optional —', 'woocommerce-product-feed-openai' ),
-					'newborn' => 'newborn',
-					'infant'  => 'infant',
-					'toddler' => 'toddler',
-					'kids'    => 'kids',
-					'adult'   => 'adult',
-				],
-				'placeholder' => $this->get_attribute_placeholder( $product, 'pa_age_group' ),
-			]
-		);
-
-		echo '</div><div class="options_group">';
-
-		woocommerce_wp_text_input(
-			[
-				'id'                => '_wpfoai_age_restriction',
-				'label'             => __( 'Age restriction', 'woocommerce-product-feed-openai' ),
-				'type'              => 'number',
-				'custom_attributes' => [
-					'min'  => '0',
-					'step' => '1',
-				],
-			]
-		);
-
-		woocommerce_wp_text_input(
-			[
-				'id'    => '_wpfoai_warning',
-				'label' => __( 'Warning text', 'woocommerce-product-feed-openai' ),
-			]
-		);
-
-		woocommerce_wp_text_input(
-			[
-				'id'          => '_wpfoai_warning_url',
-				'label'       => __( 'Warning URL', 'woocommerce-product-feed-openai' ),
-				'placeholder' => 'https://',
-			]
-		);
-
-		echo '</div><div class="options_group">';
-
-		woocommerce_wp_text_input(
-			[
-				'id'          => '_wpfoai_color',
-				'label'       => __( 'Color (override)', 'woocommerce-product-feed-openai' ),
-				'description' => __( 'Used if attribute pa_color is not set.', 'woocommerce-product-feed-openai' ),
-				'placeholder' => $this->get_attribute_placeholder( $product, 'pa_color' ),
-			]
-		);
-
-		woocommerce_wp_text_input(
-			[
-				'id'          => '_wpfoai_size',
-				'label'       => __( 'Size (override)', 'woocommerce-product-feed-openai' ),
-				'description' => __( 'Used if attribute pa_size is not set.', 'woocommerce-product-feed-openai' ),
-				'placeholder' => $this->get_attribute_placeholder( $product, 'pa_size' ),
-			]
-		);
-
-		woocommerce_wp_select(
-			[
-				'id'          => '_wpfoai_size_system',
-				'label'       => __( 'Size system', 'woocommerce-product-feed-openai' ),
-				'options'     => [
-					''    => __( '— Select —', 'woocommerce-product-feed-openai' ),
-					'US'  => 'US',
-					'UK'  => 'UK',
-					'EU'  => 'EU',
-					'FR'  => 'FR',
-					'DE'  => 'DE',
-					'IT'  => 'IT',
-					'JP'  => 'JP',
-					'CN'  => 'CN',
-					'MEX' => 'MEX',
-					'BR'  => 'BR',
-				],
-				'description' => __( 'Size measurement system.', 'woocommerce-product-feed-openai' ),
-			]
-		);
-
-		woocommerce_wp_select(
-			[
-				'id'      => '_wpfoai_gender',
-				'label'   => __( 'Target gender', 'woocommerce-product-feed-openai' ),
-				'options' => [
-					''       => __( '— Select —', 'woocommerce-product-feed-openai' ),
-					'male'   => 'Male',
-					'female' => 'Female',
-					'unisex' => 'Unisex',
-				],
-			]
-		);
-
-		echo '</div><div class="options_group">';
-
-		woocommerce_wp_text_input(
-			[
-				'id'          => '_wpfoai_video_link',
-				'label'       => __( 'Product video URL', 'woocommerce-product-feed-openai' ),
-				'placeholder' => 'https://',
-			]
-		);
-
-		woocommerce_wp_text_input(
-			[
-				'id'          => '_wpfoai_model_3d_link',
-				'label'       => __( '3D model URL', 'woocommerce-product-feed-openai' ),
-				'placeholder' => 'https://',
-			]
-		);
-
-		echo '</div><div class="options_group">';
-
-		woocommerce_wp_textarea_input(
-			[
-				'id'    => '_wpfoai_q_and_a',
-				'label' => __( 'Q&A (plain text)', 'woocommerce-product-feed-openai' ),
-				'rows'  => 3,
-			]
-		);
-
-		echo '</div><div class="options_group">';
-
-		woocommerce_wp_text_input(
-			[
-				'id'    => '_wpfoai_applicable_taxes_fees',
-				'label' => __( 'Additional taxes/fees (e.g., 7 USD)', 'woocommerce-product-feed-openai' ),
-			]
-		);
-
-		woocommerce_wp_text_input(
-			[
-				'id'    => '_wpfoai_unit_pricing_measure',
-				'label' => __( 'Unit pricing measure (e.g., 16 oz)', 'woocommerce-product-feed-openai' ),
-			]
-		);
-
-		woocommerce_wp_text_input(
-			[
-				'id'    => '_wpfoai_base_measure',
-				'label' => __( 'Base measure (e.g., 1 oz)', 'woocommerce-product-feed-openai' ),
-			]
-		);
-
-		woocommerce_wp_text_input(
-			[
-				'id'    => '_wpfoai_pricing_trend',
-				'label' => __( 'Pricing trend (short text)', 'woocommerce-product-feed-openai' ),
-			]
-		);
-
-		echo '</div><div class="options_group">';
-
-		woocommerce_wp_text_input(
-			[
-				'id'    => '_wpfoai_availability_date',
-				'label' => __( 'Availability date (YYYY-MM-DD)', 'woocommerce-product-feed-openai' ),
-			]
-		);
-
-		woocommerce_wp_text_input(
-			[
-				'id'    => '_wpfoai_expiration_date',
-				'label' => __( 'Expiration date (YYYY-MM-DD)', 'woocommerce-product-feed-openai' ),
-			]
-		);
-
-		echo '</div><div class="options_group">';
-
-		woocommerce_wp_text_input(
-			[
-				'id'    => '_wpfoai_popularity_score',
-				'label' => __( 'Popularity score (0–5)', 'woocommerce-product-feed-openai' ),
-			]
-		);
-
-		woocommerce_wp_text_input(
-			[
-				'id'    => '_wpfoai_return_rate',
-				'label' => __( 'Return rate (%)', 'woocommerce-product-feed-openai' ),
-			]
-		);
-
-		woocommerce_wp_text_input(
-			[
-				'id'    => '_wpfoai_geo_price',
-				'label' => __( 'Geo price (e.g., 79.99 USD (CA))', 'woocommerce-product-feed-openai' ),
-			]
-		);
-
-		woocommerce_wp_text_input(
-			[
-				'id'    => '_wpfoai_geo_availability',
-				'label' => __( 'Geo availability (e.g., in_stock (TX), out_of_stock (NY))', 'woocommerce-product-feed-openai' ),
-			]
-		);
-
-		echo '</div><div class="options_group">';
-
-		woocommerce_wp_text_input(
-			[
-				'id'    => '_wpfoai_related_product_id',
-				'label' => __( 'Related product IDs (CSV)', 'woocommerce-product-feed-openai' ),
-			]
-		);
-
-		woocommerce_wp_select(
-			[
-				'id'      => '_wpfoai_relationship_type',
-				'label'   => __( 'Relationship type', 'woocommerce-product-feed-openai' ),
-				'options' => [
-					''                  => __( '— Optional —', 'woocommerce-product-feed-openai' ),
-					'part_of_set'       => 'part_of_set',
-					'required_part'     => 'required_part',
-					'often_bought_with' => 'often_bought_with',
-					'substitute'        => 'substitute',
-					'different_brand'   => 'different_brand',
-					'accessory'         => 'accessory',
-				],
-			]
-		);
-
-		echo '</div>';
-
-		$rest_url    = rest_url( 'wc/v3/openai-feed' );
-		$preview_url = add_query_arg(
-			[
-				'product_id' => get_the_ID(),
-				'_wpnonce'   => wp_create_nonce( 'wp_rest' ),
-			],
-			$rest_url
-		);
-		echo '<p style="margin: 8px 0;">' . esc_html__( 'Preview this product in the feed (admin-only):', 'woocommerce-product-feed-openai' ) . ' ';
-		echo '<a href="' . esc_url( $preview_url ) . '" target="_blank">' . esc_html__( 'Open preview', 'woocommerce-product-feed-openai' ) . '</a></p>';
-
-		echo '</div>';
-	}
-
-	/**
-	 * Get placeholder text from product attribute
-	 *
-	 * Helper method to reduce redundancy when showing attribute fallbacks.
-	 *
-	 * @param \WC_Product|null $product Product object.
-	 * @param string           $attribute_name Attribute name (e.g., 'pa_brand').
-	 * @return string Placeholder text from attribute or empty string.
-	 */
-	private function get_attribute_placeholder( ?\WC_Product $product, string $attribute_name ): string {
-		return ( $product && $product->get_attribute( $attribute_name ) ) ? $product->get_attribute( $attribute_name ) : '';
+		include __DIR__ . '/Templates/ProductDataPanel.php';
 	}
 
 	/**
@@ -396,7 +79,6 @@ class ProductFieldsController {
 	 * @param \WC_Product $product Product object being saved.
 	 */
 	public function save_product_fields( \WC_Product $product ): void {
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		if ( ! isset( $_POST['woocommerce_meta_nonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['woocommerce_meta_nonce'] ), 'woocommerce_save_data' ) ) {
 			return;
 		}
@@ -406,30 +88,8 @@ class ProductFieldsController {
 		}
 
 		$text_keys = [
-			'_gtin',
-			'_mpn',
-			'_brand',
-			'_wpfoai_material',
-			'_wpfoai_color',
-			'_wpfoai_size',
-			'_wpfoai_size_system',
-			'_wpfoai_gender',
-			'_wpfoai_warning',
-			'_wpfoai_q_and_a',
-			'_wpfoai_condition',
-			'_wpfoai_age_group',
-			'_wpfoai_applicable_taxes_fees',
-			'_wpfoai_unit_pricing_measure',
-			'_wpfoai_base_measure',
-			'_wpfoai_pricing_trend',
-			'_wpfoai_availability_date',
-			'_wpfoai_expiration_date',
-			'_wpfoai_geo_price',
-			'_wpfoai_geo_availability',
-			'_wpfoai_related_product_id',
-			'_wpfoai_relationship_type',
-			'_wpfoai_popularity_score',
-			'_wpfoai_return_rate',
+			self::KEY_MPN,
+			self::KEY_CONDITION,
 		];
 
 		foreach ( $text_keys as $key ) {
@@ -439,24 +99,7 @@ class ProductFieldsController {
 			}
 		}
 
-		$url_keys = [
-			'_wpfoai_warning_url',
-			'_wpfoai_video_link',
-			'_wpfoai_model_3d_link',
-		];
-
-		foreach ( $url_keys as $key ) {
-			if ( isset( $_POST[ $key ] ) ) {
-				$val = esc_url_raw( wp_unslash( $_POST[ $key ] ) );
-				$product->update_meta_data( $key, $val );
-			}
-		}
-
-		if ( isset( $_POST['_wpfoai_age_restriction'] ) ) {
-			$product->update_meta_data( '_wpfoai_age_restriction', max( 0, absint( wp_unslash( $_POST['_wpfoai_age_restriction'] ) ) ) );
-		}
-
-		$product->update_meta_data( '_wpfoai_disable_search', isset( $_POST['_wpfoai_disable_search'] ) ? 'yes' : 'no' );
-		$product->update_meta_data( '_wpfoai_disable_checkout', isset( $_POST['_wpfoai_disable_checkout'] ) ? 'yes' : 'no' );
+		$product->update_meta_data( self::KEY_DISABLE_SEARCH, isset( $_POST[ self::KEY_DISABLE_SEARCH ] ) ? 'yes' : 'no' );
+		$product->update_meta_data( self::KEY_DISABLE_CHECKOUT, isset( $_POST[ self::KEY_DISABLE_CHECKOUT ] ) ? 'yes' : 'no' );
 	}
 }

--- a/src/Platforms/OpenAI/ProductFieldsController.php
+++ b/src/Platforms/OpenAI/ProductFieldsController.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-namespace Automattic\WooCommerce\ProductFeedForOpenAI\Admin\Controllers;
+namespace Automattic\WooCommerce\ProductFeedForOpenAI\Platforms\OpenAI;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/src/Platforms/OpenAI/ProductFieldsController.php
+++ b/src/Platforms/OpenAI/ProductFieldsController.php
@@ -15,7 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Handles WooCommerce product data tab for OpenAI feed attributes
- *
  */
 class ProductFieldsController {
 
@@ -79,7 +78,7 @@ class ProductFieldsController {
 	 * @param \WC_Product $product Product object being saved.
 	 */
 	public function save_product_fields( \WC_Product $product ): void {
-		if ( ! isset( $_POST['woocommerce_meta_nonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['woocommerce_meta_nonce'] ), 'woocommerce_save_data' ) ) {
+		if ( ! isset( $_POST['woocommerce_meta_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['woocommerce_meta_nonce'] ) ), 'woocommerce_save_data' ) ) {
 			return;
 		}
 

--- a/src/Platforms/OpenAI/ProductMapper.php
+++ b/src/Platforms/OpenAI/ProductMapper.php
@@ -461,7 +461,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 */
 	protected function get_condition( \WC_Product $product ): string {
 		$condition = $product->get_meta( ProductFieldsController::KEY_CONDITION );
-		return $condition ?? 'new';
+		return empty( $condition ) ? 'new' : $condition;
 	}
 
 	/**

--- a/src/Platforms/OpenAI/ProductMapper.php
+++ b/src/Platforms/OpenAI/ProductMapper.php
@@ -278,7 +278,7 @@ final class ProductMapper implements ProductMapperInterface {
 			'shipping'                  => 'get_shipping',
 			'pickup_method'             => 'get_pickup_method',
 			'pickup_sla'                => 'get_pickup_sla',
-			'related_product_id'        => 'get_related_product_id',
+			'related_product_id'        => 'get_related_product_id', // because FeedSchema::get_schema does not include this field.
 			'relationship_type'         => 'get_relationship_type',
 		];
 	}

--- a/src/Platforms/OpenAI/ProductMapper.php
+++ b/src/Platforms/OpenAI/ProductMapper.php
@@ -140,6 +140,8 @@ final class ProductMapper implements ProductMapperInterface {
 
 		if ( $mapper_method && method_exists( $this, $mapper_method ) ) {
 			$value = $this->$mapper_method( $product, $parent_product );
+		} else {
+			$value = null;
 		}
 
 		if ( empty( $value ) && isset( $config['default'] ) ) {
@@ -256,15 +258,11 @@ final class ProductMapper implements ProductMapperInterface {
 			'dimensions'                => 'get_dimensions',
 			'image_link'                => 'get_image_link',
 			'additional_image_link'     => 'get_additional_image_link',
-			'video_link'                => 'get_video_link',
-			'model_3d_link'             => 'get_model_3d_link',
 			'price'                     => 'get_price',
 			'sale_price'                => 'get_sale_price',
 			'sale_price_effective_date' => 'get_sale_price_effective_date',
 			'availability'              => 'get_availability',
 			'inventory_quantity'        => 'get_inventory_quantity',
-			'availability_date'         => 'get_availability_date',
-			'expiration_date'           => 'get_expiration_date',
 			'item_group_id'             => 'get_item_group_id',
 			'item_group_title'          => 'get_item_group_title',
 			'color'                     => 'get_color',
@@ -280,10 +278,6 @@ final class ProductMapper implements ProductMapperInterface {
 			'shipping'                  => 'get_shipping',
 			'pickup_method'             => 'get_pickup_method',
 			'pickup_sla'                => 'get_pickup_sla',
-			'warning'                   => 'get_warning',
-			'warning_url'               => 'get_warning_url',
-			'age_restriction'           => 'get_age_restriction',
-			'q_and_a'                   => 'get_q_and_a',
 			'related_product_id'        => 'get_related_product_id',
 			'relationship_type'         => 'get_relationship_type',
 		];
@@ -455,7 +449,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product material or null.
 	 */
 	protected function get_material( \WC_Product $product ): ?string {
-		// Using pa_material attribute from WooCommerce Product Brands or similar taxonomy
+		// Using pa_material attribute from WooCommerce Product Brands or similar taxonomy.
 		return $product->get_attribute( 'pa_material' ) ? $product->get_attribute( 'pa_material' ) : null;
 	}
 
@@ -466,7 +460,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string Product condition, defaults to 'new'.
 	 */
 	protected function get_condition( \WC_Product $product ): string {
-		$condition =$product->get_meta( ProductFieldsController::KEY_CONDITION );
+		$condition = $product->get_meta( ProductFieldsController::KEY_CONDITION );
 		return $condition ?? 'new';
 	}
 
@@ -477,7 +471,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product age group or null.
 	 */
 	protected function get_age_group( \WC_Product $product ): ?string {
-		// Using pa_age_group attribute from WooCommerce
+		// Using pa_age_group attribute from WooCommerce.
 		return $product->get_attribute( 'pa_age_group' ) ? $product->get_attribute( 'pa_age_group' ) : null;
 	}
 
@@ -554,26 +548,6 @@ final class ProductMapper implements ProductMapperInterface {
 	}
 
 	/**
-	 * Get product video link.
-	 *
-	 * @param \WC_Product $product Product object.
-	 * @return string|null Product video URL or null.
-	 */
-	protected function get_video_link( \WC_Product $product ): ?string {
-		return null;
-	}
-
-	/**
-	 * Get product 3D model link.
-	 *
-	 * @param \WC_Product $product Product object.
-	 * @return string|null Product 3D model URL or null.
-	 */
-	protected function get_model_3d_link( \WC_Product $product ): ?string {
-		return null;
-	}
-
-	/**
 	 * Get product price with currency.
 	 *
 	 * @param \WC_Product $product Product object.
@@ -637,26 +611,6 @@ final class ProductMapper implements ProductMapperInterface {
 	}
 
 	/**
-	 * Get product availability date.
-	 *
-	 * @param \WC_Product $product Product object.
-	 * @return string|null Product availability date or null.
-	 */
-	protected function get_availability_date( \WC_Product $product ): ?string {
-		return null;
-	}
-
-	/**
-	 * Get product expiration date.
-	 *
-	 * @param \WC_Product $product Product object.
-	 * @return string|null Product expiration date or null.
-	 */
-	protected function get_expiration_date( \WC_Product $product ): ?string {
-		return null;
-	}
-
-	/**
 	 * Get product item group ID.
 	 *
 	 * @param \WC_Product      $product Product object.
@@ -688,7 +642,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product color or null.
 	 */
 	protected function get_color( \WC_Product $product ): ?string {
-		// Using pa_color attribute from WooCommerce - no override field
+		// Using pa_color attribute from WooCommerce - no override field.
 		return $product->get_attribute( 'pa_color' ) ? $product->get_attribute( 'pa_color' ) : null;
 	}
 
@@ -699,7 +653,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product size or null.
 	 */
 	protected function get_size( \WC_Product $product ): ?string {
-		// Using pa_size attribute from WooCommerce - no override field
+		// Using pa_size attribute from WooCommerce - no override field.
 		return $product->get_attribute( 'pa_size' ) ? $product->get_attribute( 'pa_size' ) : null;
 	}
 
@@ -710,7 +664,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product size system or null.
 	 */
 	protected function get_size_system( \WC_Product $product ): ?string {
-		// Using pa_size_system attribute from WooCommerce - no override field
+		// Using pa_size_system attribute from WooCommerce - no override field.
 		return $product->get_attribute( 'pa_size_system' ) ? $product->get_attribute( 'pa_size_system' ) : null;
 	}
 
@@ -721,7 +675,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product gender or null.
 	 */
 	protected function get_gender( \WC_Product $product ): ?string {
-		// Using pa_gender attribute from WooCommerce - no override field
+		// Using pa_gender attribute from WooCommerce - no override field.
 		return $product->get_attribute( 'pa_gender' ) ? $product->get_attribute( 'pa_gender' ) : null;
 	}
 
@@ -813,46 +767,6 @@ final class ProductMapper implements ProductMapperInterface {
 			$pickup_sla = $this->settings->get( 'pickup_sla' );
 			return $pickup_sla ? (string) $pickup_sla : null;
 		}
-		return null;
-	}
-
-	/**
-	 * Get product warning.
-	 *
-	 * @param \WC_Product $product Product object.
-	 * @return string|null Product warning or null.
-	 */
-	protected function get_warning( \WC_Product $product ): ?string {
-		return null;
-	}
-
-	/**
-	 * Get product warning URL.
-	 *
-	 * @param \WC_Product $product Product object.
-	 * @return string|null Product warning URL or null.
-	 */
-	protected function get_warning_url( \WC_Product $product ): ?string {
-		return null;
-	}
-
-	/**
-	 * Get product age restriction.
-	 *
-	 * @param \WC_Product $product Product object.
-	 * @return string|null Product age restriction or null.
-	 */
-	protected function get_age_restriction( \WC_Product $product ): ?string {
-		return null;
-	}
-
-	/**
-	 * Get product Q and A.
-	 *
-	 * @param \WC_Product $product Product object.
-	 * @return string|null Product Q and A or null.
-	 */
-	protected function get_q_and_a( \WC_Product $product ): ?string {
 		return null;
 	}
 

--- a/src/Platforms/OpenAI/ProductMapper.php
+++ b/src/Platforms/OpenAI/ProductMapper.php
@@ -140,8 +140,6 @@ final class ProductMapper implements ProductMapperInterface {
 
 		if ( $mapper_method && method_exists( $this, $mapper_method ) ) {
 			$value = $this->$mapper_method( $product, $parent_product );
-		} else {
-			$value = $this->get_meta_value( $product, "_wpfoai_{$field}" );
 		}
 
 		if ( empty( $value ) && isset( $config['default'] ) ) {
@@ -229,26 +227,6 @@ final class ProductMapper implements ProductMapperInterface {
 	}
 
 	/**
-	 * Get meta value with fallback (with caching to prevent N+1 queries)
-	 *
-	 * @param \WC_Product $product Product object.
-	 * @param string      $key     Meta key to retrieve.
-	 * @return string|null Meta value or null if not found.
-	 */
-	protected function get_meta_value( \WC_Product $product, string $key ): ?string {
-		$product_id = $product->get_id();
-
-		if ( ! isset( $this->product_meta_cache[ $product_id ] ) ) {
-			$this->product_meta_cache[ $product_id ] = get_post_meta( $product_id );
-		}
-
-		$value = isset( $this->product_meta_cache[ $product_id ][ $key ][0] )
-			? $this->product_meta_cache[ $product_id ][ $key ][0]
-			: null;
-		return ! empty( $value ) ? wp_strip_all_tags( $value ) : null;
-	}
-
-	/**
 	 * Get field mappings for OpenAI feed format
 	 *
 	 * Maps OpenAI field names to ProductMapper method names.
@@ -321,7 +299,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string 'true' or 'false'.
 	 */
 	private function get_enable_with_override( \WC_Product $product, string $meta_key, string $setting_key, string $default_value ): string {
-		$disable_override = $this->get_meta_value( $product, $meta_key );
+		$disable_override = $product->get_meta( $meta_key );
 
 		// Only disable if explicitly set to 'yes'.
 		// Empty/null/no all mean "don't disable" (use global default).
@@ -341,7 +319,7 @@ final class ProductMapper implements ProductMapperInterface {
 	protected function get_enable_search( \WC_Product $product, ?\WC_Product $parent_product ): string {
 		// For variations, check parent product meta; for simple products, check product meta.
 		$check_product = $parent_product ? $parent_product : $product;
-		return $this->get_enable_with_override( $check_product, '_wpfoai_disable_search', 'enable_products_default', 'true' );
+		return $this->get_enable_with_override( $check_product, ProductFieldsController::KEY_DISABLE_SEARCH, 'enable_products_default', 'true' );
 	}
 
 	/**
@@ -354,7 +332,7 @@ final class ProductMapper implements ProductMapperInterface {
 	protected function get_enable_checkout( \WC_Product $product, ?\WC_Product $parent_product ): string {
 		// For variations, check parent product meta; for simple products, check product meta.
 		$check_product = $parent_product ? $parent_product : $product;
-		return $this->get_enable_with_override( $check_product, '_wpfoai_disable_checkout', 'enable_products_default', 'false' );
+		return $this->get_enable_with_override( $check_product, ProductFieldsController::KEY_DISABLE_CHECKOUT, 'enable_products_default', 'false' );
 	}
 
 	/**
@@ -395,7 +373,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string Product permalink URL.
 	 */
 	protected function get_link( \WC_Product $product ): string {
-		return get_permalink( $product->get_id() );
+		return $product->get_permalink();
 	}
 
 	/**
@@ -405,11 +383,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product GTIN or null.
 	 */
 	protected function get_gtin( \WC_Product $product ): ?string {
-		$override = $this->get_meta_value( $product, '_gtin' );
-		if ( empty( $override ) ) {
-			return $product->get_global_unique_id();
-		}
-		return $override;
+		return $product->get_global_unique_id();
 	}
 
 	/**
@@ -419,13 +393,12 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product MPN or null.
 	 */
 	protected function get_mpn( \WC_Product $product ): ?string {
-		$mpn = $this->get_meta_value( $product, '_mpn' );
+		$mpn = $product->get_meta( ProductFieldsController::KEY_MPN );
 		if ( $mpn ) {
 			return $mpn;
 		}
 
-		$gtin = $this->get_meta_value( $product, '_gtin' );
-		if ( ! $gtin ) {
+		if ( ! $product->get_global_unique_id() ) {
 			return $this->generate_mpn( $product );
 		}
 
@@ -470,9 +443,6 @@ final class ProductMapper implements ProductMapperInterface {
 		if ( ! $brand && $parent_product ) {
 			$brand = $parent_product->get_attribute( 'pa_brand' );
 		}
-		if ( ! $brand ) {
-			$brand = $this->get_meta_value( $product, '_brand' );
-		}
 		return $brand ? $brand : 'Generic';
 	}
 
@@ -483,6 +453,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product material or null.
 	 */
 	protected function get_material( \WC_Product $product ): ?string {
+		// Using pa_material attribute from WooCommerce Product Brands or similar taxonomy
 		return $product->get_attribute( 'pa_material' ) ? $product->get_attribute( 'pa_material' ) : null;
 	}
 
@@ -490,10 +461,11 @@ final class ProductMapper implements ProductMapperInterface {
 	 * Get product condition.
 	 *
 	 * @param \WC_Product $product Product object.
-	 * @return string|null Product condition or null.
+	 * @return string Product condition, defaults to 'new'.
 	 */
-	protected function get_condition( \WC_Product $product ): ?string {
-		return $this->get_meta_value( $product, '_wpfoai_condition' );
+	protected function get_condition( \WC_Product $product ): string {
+		$condition =$product->get_meta( ProductFieldsController::KEY_CONDITION );
+		return $condition ?? 'new';
 	}
 
 	/**
@@ -503,7 +475,8 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product age group or null.
 	 */
 	protected function get_age_group( \WC_Product $product ): ?string {
-		return $this->get_meta_value( $product, '_wpfoai_age_group' );
+		// Using pa_age_group attribute from WooCommerce
+		return $product->get_attribute( 'pa_age_group' ) ? $product->get_attribute( 'pa_age_group' ) : null;
 	}
 
 	/**
@@ -585,7 +558,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product video URL or null.
 	 */
 	protected function get_video_link( \WC_Product $product ): ?string {
-		return $this->get_meta_value( $product, '_wpfoai_video_link' );
+		return null;
 	}
 
 	/**
@@ -595,7 +568,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product 3D model URL or null.
 	 */
 	protected function get_model_3d_link( \WC_Product $product ): ?string {
-		return $this->get_meta_value( $product, '_wpfoai_model_3d_link' );
+		return null;
 	}
 
 	/**
@@ -668,7 +641,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product availability date or null.
 	 */
 	protected function get_availability_date( \WC_Product $product ): ?string {
-		return $this->get_meta_value( $product, '_wpfoai_availability_date' );
+		return null;
 	}
 
 	/**
@@ -678,7 +651,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product expiration date or null.
 	 */
 	protected function get_expiration_date( \WC_Product $product ): ?string {
-		return $this->get_meta_value( $product, '_wpfoai_expiration_date' );
+		return null;
 	}
 
 	/**
@@ -713,6 +686,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product color or null.
 	 */
 	protected function get_color( \WC_Product $product ): ?string {
+		// Using pa_color attribute from WooCommerce - no override field
 		return $product->get_attribute( 'pa_color' ) ? $product->get_attribute( 'pa_color' ) : null;
 	}
 
@@ -723,6 +697,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product size or null.
 	 */
 	protected function get_size( \WC_Product $product ): ?string {
+		// Using pa_size attribute from WooCommerce - no override field
 		return $product->get_attribute( 'pa_size' ) ? $product->get_attribute( 'pa_size' ) : null;
 	}
 
@@ -733,6 +708,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product size system or null.
 	 */
 	protected function get_size_system( \WC_Product $product ): ?string {
+		// Using pa_size_system attribute from WooCommerce - no override field
 		return $product->get_attribute( 'pa_size_system' ) ? $product->get_attribute( 'pa_size_system' ) : null;
 	}
 
@@ -743,6 +719,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product gender or null.
 	 */
 	protected function get_gender( \WC_Product $product ): ?string {
+		// Using pa_gender attribute from WooCommerce - no override field
 		return $product->get_attribute( 'pa_gender' ) ? $product->get_attribute( 'pa_gender' ) : null;
 	}
 
@@ -844,17 +821,17 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product warning or null.
 	 */
 	protected function get_warning( \WC_Product $product ): ?string {
-		return $this->get_meta_value( $product, '_wpfoai_warning' );
+		return null;
 	}
 
 	/**
-	 * Get product warning.
+	 * Get product warning URL.
 	 *
 	 * @param \WC_Product $product Product object.
-	 * @return string|null Product warning or null.
+	 * @return string|null Product warning URL or null.
 	 */
 	protected function get_warning_url( \WC_Product $product ): ?string {
-		return $this->get_meta_value( $product, '_wpfoai_warning_url' );
+		return null;
 	}
 
 	/**
@@ -864,7 +841,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product age restriction or null.
 	 */
 	protected function get_age_restriction( \WC_Product $product ): ?string {
-		return $this->get_meta_value( $product, '_wpfoai_age_restriction' );
+		return null;
 	}
 
 	/**
@@ -874,7 +851,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product Q and A or null.
 	 */
 	protected function get_q_and_a( \WC_Product $product ): ?string {
-		return $this->get_meta_value( $product, '_wpfoai_q_and_a' );
+		return null;
 	}
 
 	/**

--- a/src/Platforms/OpenAI/ProductMapper.php
+++ b/src/Platforms/OpenAI/ProductMapper.php
@@ -278,7 +278,7 @@ final class ProductMapper implements ProductMapperInterface {
 			'shipping'                  => 'get_shipping',
 			'pickup_method'             => 'get_pickup_method',
 			'pickup_sla'                => 'get_pickup_sla',
-			'related_product_id'        => 'get_related_product_id', // because FeedSchema::get_schema does not include this field.
+			'related_product_id'        => 'get_related_product_id',
 			'relationship_type'         => 'get_relationship_type',
 		];
 	}
@@ -424,7 +424,20 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product category path or null.
 	 */
 	protected function get_product_category( \WC_Product $product ): ?string {
-		return $this->get_category_path( $product );
+		$terms = get_the_terms( $product->get_id(), 'product_cat' );
+		if ( ! $terms || is_wp_error( $terms ) ) {
+			return null;
+		}
+
+		$names = [];
+		foreach ( $terms as $term ) {
+			if ( 'uncategorized' === $term->slug ) {
+				continue;
+			}
+			$names[] = $term->name;
+		}
+
+		return empty( $names ) ? null : implode( ', ', $names );
 	}
 
 	/**
@@ -819,78 +832,6 @@ final class ProductMapper implements ProductMapperInterface {
 		}
 
 		return null;
-	}
-
-	/**
-	 * Get category path.
-	 *
-	 * @param \WC_Product $product Product object.
-	 * @return string|null Category path or null.
-	 */
-	private function get_category_path( \WC_Product $product ): ?string {
-		$terms = get_the_terms( $product->get_id(), 'product_cat' );
-		if ( ! $terms || is_wp_error( $terms ) ) {
-			return null;
-		}
-
-		$deepest_term = null;
-		$max_depth    = -1;
-
-		foreach ( $terms as $term ) {
-			$depth = $this->get_category_depth( $term );
-			if ( $depth > $max_depth ) {
-				$max_depth    = $depth;
-				$deepest_term = $term;
-			}
-		}
-
-		if ( ! $deepest_term ) {
-			return null;
-		}
-
-		return $this->build_category_path( $deepest_term );
-	}
-
-	/**
-	 * Get category depth.
-	 *
-	 * @param \WP_Term $term Term object.
-	 * @return int Category depth.
-	 */
-	private function get_category_depth( \WP_Term $term ): int {
-		$depth   = 0;
-		$current = $term;
-
-		while ( $current && $current->parent ) {
-			$current = get_term( $current->parent, 'product_cat' );
-			if ( is_wp_error( $current ) ) {
-				break;
-			}
-			++$depth;
-		}
-
-		return $depth;
-	}
-
-	/**
-	 * Build category path string.
-	 *
-	 * @param \WP_Term $term Term object.
-	 * @return string Category path string.
-	 */
-	private function build_category_path( \WP_Term $term ): string {
-		$path    = [ $term->name ];
-		$current = $term;
-
-		while ( $current->parent ) {
-			$current = get_term( $current->parent, 'product_cat' );
-			if ( is_wp_error( $current ) ) {
-				break;
-			}
-			array_unshift( $path, $current->name );
-		}
-
-		return implode( ' > ', $path );
 	}
 
 	/**

--- a/src/Platforms/OpenAI/ProductMapper.php
+++ b/src/Platforms/OpenAI/ProductMapper.php
@@ -284,6 +284,8 @@ final class ProductMapper implements ProductMapperInterface {
 			'warning_url'               => 'get_warning_url',
 			'age_restriction'           => 'get_age_restriction',
 			'q_and_a'                   => 'get_q_and_a',
+			'related_product_id'        => 'get_related_product_id',
+			'relationship_type'         => 'get_relationship_type',
 		];
 	}
 
@@ -331,7 +333,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 */
 	protected function get_enable_checkout( \WC_Product $product, ?\WC_Product $parent_product ): string {
 		// For variations, check parent product meta; for simple products, check product meta.
-		$check_product = $parent_product ? $parent_product : $product;
+		$check_product = $parent_product ?? $product;
 		return $this->get_enable_with_override( $check_product, ProductFieldsController::KEY_DISABLE_CHECKOUT, 'enable_products_default', 'false' );
 	}
 
@@ -851,6 +853,57 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string|null Product Q and A or null.
 	 */
 	protected function get_q_and_a( \WC_Product $product ): ?string {
+		return null;
+	}
+
+	/**
+	 * Get related product ID.
+	 *
+	 * Returns IDs from upsell or cross-sell products as a comma-separated list.
+	 * Prioritizes upsell products over cross-sell products.
+	 *
+	 * @param \WC_Product $product Product object.
+	 * @return string|null Comma-separated list of related product IDs or null.
+	 */
+	protected function get_related_product_id( \WC_Product $product ): ?string {
+		$upsell_ids     = $product->get_upsell_ids();
+		$cross_sell_ids = $product->get_cross_sell_ids();
+
+		// Prioritize upsell over cross-sell.
+		if ( ! empty( $upsell_ids ) ) {
+			return implode( ',', $upsell_ids );
+		}
+
+		if ( ! empty( $cross_sell_ids ) ) {
+			return implode( ',', $cross_sell_ids );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get relationship type.
+	 *
+	 * Returns the type of relationship for related products:
+	 * - 'substitute' for upsell products (takes priority if both exist)
+	 * - 'often_bought_with' for cross-sell products
+	 *
+	 * @param \WC_Product $product Product object.
+	 * @return string|null Relationship type enum value or null.
+	 */
+	protected function get_relationship_type( \WC_Product $product ): ?string {
+		$upsell_ids     = $product->get_upsell_ids();
+		$cross_sell_ids = $product->get_cross_sell_ids();
+
+		// Prioritize upsell (substitute) over cross-sell (often_bought_with).
+		if ( ! empty( $upsell_ids ) ) {
+			return 'substitute';
+		}
+
+		if ( ! empty( $cross_sell_ids ) ) {
+			return 'often_bought_with';
+		}
+
 		return null;
 	}
 

--- a/src/Platforms/OpenAI/Templates/ProductDataPanel.php
+++ b/src/Platforms/OpenAI/Templates/ProductDataPanel.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * OpenAI Feed product data panel template
+ *
+ * This template is included from ProductFieldsController::render_product_data_panel()
+ *
+ * @package Automattic\WooCommerce\ProductFeedForOpenAI
+ */
+
+declare(strict_types=1);
+
+use Automattic\WooCommerce\ProductFeedForOpenAI\Platforms\OpenAI\ProductFieldsController;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$product = wc_get_product( get_the_ID() );
+if ( ! $product instanceof \WC_Product ) {
+	return;
+}
+
+?>
+
+<div id="wpfoai_product_data" class="panel woocommerce_options_panel hidden">
+
+	<div class="options_group">
+
+		<?php
+		woocommerce_wp_checkbox(
+			[
+				'id'          => ProductFieldsController::KEY_DISABLE_SEARCH,
+				'value'       => $product->get_meta( ProductFieldsController::KEY_DISABLE_SEARCH ) === 'yes' ? 'yes' : 'no',
+				'label'       => __( 'Disable search', 'woocommerce-product-feed-openai' ),
+				'description' => __( 'Overrides global default for this product.', 'woocommerce-product-feed-openai' ),
+			]
+		);
+
+		woocommerce_wp_checkbox(
+			[
+				'id'          => ProductFieldsController::KEY_DISABLE_CHECKOUT,
+				'value'       => $product->get_meta( ProductFieldsController::KEY_DISABLE_CHECKOUT ) === 'yes' ? 'yes' : 'no',
+				'label'       => __( 'Disable checkout', 'woocommerce-product-feed-openai' ),
+				'description' => __( 'Requires search to be enabled.', 'woocommerce-product-feed-openai' ),
+			]
+		);
+		?>
+
+	</div>
+
+	<div class="options_group">
+
+		<?php
+		woocommerce_wp_text_input(
+			[
+				'id'          => ProductFieldsController::KEY_MPN,
+				'label'       => __( 'MPN', 'woocommerce-product-feed-openai' ),
+				'desc_tip'    => true,
+				'description' => __( 'Manufacturer Part Number. Required if GTIN does not exist.', 'woocommerce-product-feed-openai' ),
+			]
+		);
+		?>
+
+	</div>
+
+	<div class="options_group">
+
+		<?php
+		woocommerce_wp_select(
+			[
+				'id'          => ProductFieldsController::KEY_CONDITION,
+				'label'       => __( 'Condition', 'woocommerce-product-feed-openai' ),
+				'options'     => [
+					''            => __( 'new (default)', 'woocommerce-product-feed-openai' ),
+					'new'         => __( 'new', 'woocommerce-product-feed-openai' ),
+					'refurbished' => __( 'refurbished', 'woocommerce-product-feed-openai' ),
+					'used'        => __( 'used', 'woocommerce-product-feed-openai' ),
+				],
+				'desc_tip'    => true,
+				'description' => __( 'Only required if product condition differs from new.', 'woocommerce-product-feed-openai' ),
+			]
+		);
+		?>
+
+	</div>
+
+	<?php
+	$rest_url    = rest_url( 'wc/v3/openai-feed' );
+	$preview_url = add_query_arg(
+		[
+			'product_id' => $product->get_id(),
+			'_wpnonce'   => wp_create_nonce( 'wp_rest' ),
+		],
+		$rest_url
+	);
+	?>
+	<p style="margin: 8px 0;">
+		<?php echo esc_html__( 'Preview this product in the feed (admin-only):', 'woocommerce-product-feed-openai' ); ?>
+		<a href="<?php echo esc_url( $preview_url ); ?>" target="_blank">
+			<?php echo esc_html__( 'Open preview', 'woocommerce-product-feed-openai' ); ?>
+		</a>
+	</p>
+
+</div>

--- a/tests/unit/ProductFeed/API/Controllers/ApiControllerTest.php
+++ b/tests/unit/ProductFeed/API/Controllers/ApiControllerTest.php
@@ -34,8 +34,6 @@ class ApiControllerTest extends WC_Unit_Test_Case {
 		$request->set_param( 'product_id', $product->get_id() );
 
 		$response = $this->sut->handle_preview_feed( $request );
-		$headers  = $response->get_headers();
-
 		$this->assertInstanceOf( \WP_REST_Response::class, $response );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertCount( 1, $response->get_data() );

--- a/tests/unit/ProductFeed/API/Controllers/ApiControllerTest.php
+++ b/tests/unit/ProductFeed/API/Controllers/ApiControllerTest.php
@@ -38,8 +38,6 @@ class ApiControllerTest extends WC_Unit_Test_Case {
 
 		$this->assertInstanceOf( \WP_REST_Response::class, $response );
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertArrayHasKey( 'Content-Type', $headers );
-		$this->assertEquals( 'application/json; charset=utf-8', $headers['Content-Type'] );
 		$this->assertCount( 1, $response->get_data() );
 
 		// We could verify details about the response here, but those will probably change.


### PR DESCRIPTION
Related WOOPTP-38

## Description

<!-- Provide a brief description of the changes in this PR -->

We simplify the Product Fields Data and just include the must-have or critical values :

- Field `gtin` is using the current Woo data `$product->get_global_unique_id()` 
- Fields `relationship_type` and `related_product_id` are retrieved from cross-sell and upsell products.
- Within ProductMapper, I've updated a few things to ensure it makes sense such as using `$product->get_meta` right away rather than a private method to handle it.  

# Testing instructions

<!-- Provide testing instructions here -->

Visit the product editor and it looks like this now: 

<img width="3632" height="1620" alt="Screen Shot on 2025-10-23 at 17:42:16" src="https://github.com/user-attachments/assets/8af5355e-1735-4be9-9173-9212aacd0569" />

Click the preview feed and confirm that you can see the JSON shape. Ensure that you have shipping + GTIN + description. 

# TODOs 

- [ ] Continue reviewing product mappers and update them. There a few places we can optimize. 
- [ ] Review OpenAI schema and see what we can bring more, for example, `additional_image_link`. 

## Checklist

<!-- Mark completed items with an "x" -->

- [x] `npm run test:php` does not return errors.
- [x] `npm run lint:php` does not return errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * OpenAI product editor logic reorganized; editor now served by the OpenAI platform implementation.

* **New Features**
  * Admin product panel streamlined with MPN, condition, and disable search/checkout options.
  * Preview endpoint can target a specific product.
  * Feed includes related_product_id and relationship_type fields.

* **Bug Fixes**
  * Removed obsolete feed fields and refined field mappings.

* **Tests**
  * Relaxed Content-Type assertion in preview API test.

* **Chores**
  * Updated declared WooCommerce compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->