### PR TITLE
Optimize feed generation

### DIFF
--- a/src/Admin/Controllers/AdminController.php
+++ b/src/Admin/Controllers/AdminController.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\ProductMapperInterface;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\ProductWalker;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Platforms\OpenAI\ProductMapper;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Settings\SettingsRepository;
+use Automattic\WooCommerce\ProductFeedForOpenAI\Storage\JsonFileFeed;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Storage\JsonInMemoryFeed;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -90,7 +91,7 @@ class AdminController {
 			return;
 		}
 
-		$feed   = new JsonInMemoryFeed();
+		$feed   = new JsonFileFeed( 'openai-feed' );
 		$walker = new ProductWalker( $this->product_mapper, $this->validator, $feed );
 		$walker->walk();
 
@@ -99,7 +100,7 @@ class AdminController {
 			[
 				'headers' => $headers,
 				'timeout' => 30,
-				'body'    => wp_json_encode( $feed->deliver() ),
+				'body'    => file_get_contents( $feed->get_file_path() ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			]
 		);
 

--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -19,6 +19,7 @@ use Automattic\WooCommerce\ProductFeedForOpenAI\Platforms\OpenAI\FeedValidator;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Platforms\OpenAI\ProductMapper;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Settings\SettingsRepository;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Storage\JsonFileFeed;
+use Automattic\WooCommerce\ProductFeedForOpenAI\Utils\MemoryManager;
 
 /**
  * CLI command for generating a product feed.
@@ -67,6 +68,9 @@ class Command extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
+	 * [--integration=<integration>]
+	 * : The slug of the integration to use. Required.
+	 *
 	 * [--timeout=<seconds>]
 	 * : The number of seconds to extend the execution time limit per batch.
 	 * ---
@@ -97,6 +101,7 @@ class Command extends WP_CLI_Command {
 	 *
 	 * @param array $args       Positional arguments.
 	 * @param array $assoc_args Associative arguments.
+	 * @throws RuntimeException If the cURL request fails.
 	 */
 	public function generate( $args, $assoc_args ) {
 		// Read args and prepare defaults.
@@ -115,7 +120,7 @@ class Command extends WP_CLI_Command {
 		}
 
 		// Initialize the feed and walker, set them up.
-		$feed   = new JsonFileFeed();
+		$feed   = new JsonFileFeed( 'openai-feed' );
 		$walker = new ProductWalker( $this->product_mapper, $this->validator, $feed );
 		$walker->set_batch_size( $batch_size );
 		$walker->add_time_limit( $timeout );
@@ -124,13 +129,24 @@ class Command extends WP_CLI_Command {
 			WP_CLI::log( 'Starting feed generation...' );
 		}
 
+		$total_time     = microtime( true );
+		$total_items    = 0;
+		$iteration_time = microtime( true );
 		$walker->walk(
-			function ( WalkerProgress $progress ) use ( $silent ) {
+			function ( WalkerProgress $progress ) use ( $silent, &$iteration_time, &$total_items ) {
 				if ( $silent ) {
 					return;
 				}
 
-				WP_CLI::log( "Batch $progress->processed_batches/$progress->total_batch_count: Processed $progress->processed_items/$progress->total_count products" );
+				$items_count = $progress->processed_items - $total_items;
+				$total_items = $progress->processed_items; // reset.
+
+				$duration       = microtime( true ) - $iteration_time;
+				$iteration_time = microtime( true ); // reset.
+
+				$per_item = round( ( $duration / $items_count ) * 1000, 2 );
+
+				WP_CLI::log( "Batch $progress->processed_batches/$progress->total_batch_count: Processed $progress->processed_items/$progress->total_count products. Available memory: " . MemoryManager::get_available_memory() . "%. Time per item: $per_item ms" );
 			}
 		);
 
@@ -143,6 +159,7 @@ class Command extends WP_CLI_Command {
 		if ( ! $silent ) {
 			WP_CLI::success( 'Feed generated successfully' );
 			WP_CLI::log( "Path: $path" );
+			WP_CLI::log( 'Time taken: ' . intval( ( microtime( true ) - $total_time ) ) . ' seconds' );
 
 			if ( ! $send ) {
 				WP_CLI::log( 'The --send option was not provided, the feed has not been sent.' );
@@ -160,7 +177,7 @@ class Command extends WP_CLI_Command {
 			[
 				'headers' => $headers,
 				'timeout' => 30,
-				'body'    => wp_json_encode( $feed->deliver() ),
+				'body'    => file_get_contents( $feed->get_file_path() ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			]
 		);
 

--- a/src/Feed/FeedInterface.php
+++ b/src/Feed/FeedInterface.php
@@ -32,11 +32,4 @@ interface FeedInterface {
 	 * @return void
 	 */
 	public function end(): void;
-
-	/**
-	 * Deliver the feed.
-	 *
-	 * @return array An array that will be provided to WP_REST_Response.
-	 */
-	public function deliver(): array;
 }

--- a/src/Feed/ProductWalker.php
+++ b/src/Feed/ProductWalker.php
@@ -144,7 +144,7 @@ class ProductWalker {
 			$progress->processed_items += $iterated;
 			++$progress->processed_batches;
 
-			if ( is_callable( $callback ) ) {
+			if ( is_callable( $callback ) && $iterated > 0 ) {
 				$callback( $progress );
 			}
 

--- a/src/Feed/ProductWalker.php
+++ b/src/Feed/ProductWalker.php
@@ -153,7 +153,7 @@ class ProductWalker {
 			}
 
 			// We don't want to use more than half of the available memory at the beginning of the script.
-			if ( $initial_available_memory - MemoryManager::get_available_memory() > $initial_available_memory / 2 ) {
+			if ( $initial_available_memory - MemoryManager::get_available_memory() >= $initial_available_memory / 2 ) {
 				MemoryManager::flush_caches();
 			}
 		} while ( $iterated === $this->per_page );

--- a/src/Feed/ProductWalker.php
+++ b/src/Feed/ProductWalker.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\ProductFeedForOpenAI\Feed;
 
+use Automattic\WooCommerce\ProductFeedForOpenAI\Utils\MemoryManager;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -128,15 +130,16 @@ class ProductWalker {
 		// Instruct the feed to start.
 		$this->feed->start();
 
+		// Check how much memory is available at first.
+		$initial_available_memory = MemoryManager::get_available_memory();
+
 		do {
 			$result   = $this->iterate( $args, $progress ? $progress->processed_batches + 1 : 1, $this->per_page );
 			$iterated = count( $result->products );
 
-			// Indicate progress.
+			// Only done when the progress is not set. Will be modified otherwise.
 			if ( is_null( $progress ) ) {
 				$progress = WalkerProgress::from_wc_get_products_result( $result );
-			} else {
-				$progress = clone $progress;
 			}
 			$progress->processed_items += $iterated;
 			++$progress->processed_batches;
@@ -147,6 +150,11 @@ class ProductWalker {
 
 			if ( $this->time_limit > 0 ) {
 				set_time_limit( $this->time_limit );
+			}
+
+			// We don't want to use more than half of the available memory at the beginning of the script.
+			if ( $initial_available_memory - MemoryManager::get_available_memory() > $initial_available_memory / 2 ) {
+				MemoryManager::flush_caches();
 			}
 		} while ( $iterated === $this->per_page );
 

--- a/src/Storage/JsonFileFeed.php
+++ b/src/Storage/JsonFileFeed.php
@@ -43,11 +43,27 @@ class JsonFileFeed implements FeedInterface {
 	private $file_handle = null;
 
 	/**
+	 * The base name of the feed file.
+	 *
+	 * @var string
+	 */
+	private $base_name;
+
+	/**
 	 * Indicates if the feed file has been completed.
 	 *
 	 * @var bool
 	 */
 	private $file_completed = false;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $base_name The base name of the feed file.
+	 */
+	public function __construct( string $base_name ) {
+		$this->base_name = $base_name;
+	}
 
 	/**
 	 * Start the feed.
@@ -71,7 +87,7 @@ class JsonFileFeed implements FeedInterface {
 			);
 		}
 
-		$this->file_path   = $directory . wp_unique_filename( $directory, 'openai-feed.json' );
+		$this->file_path   = $directory . wp_unique_filename( $directory, $this->base_name . '.json' );
 		$this->file_handle = fopen( $this->file_path, 'w' );
 
 		if ( false === $this->file_handle ) {
@@ -118,27 +134,6 @@ class JsonFileFeed implements FeedInterface {
 
 		// Indicate that we have a complete file.
 		$this->file_completed = true;
-	}
-
-	/**
-	 * Deliver the feed and delete the temporary file.
-	 *
-	 * @return array An array that will be provided to WP_REST_Response.
-	 * @throws RuntimeException If the feed has not been completed.
-	 */
-	public function deliver(): array {
-		if ( ! $this->file_completed ) {
-			throw new RuntimeException(
-				esc_html(
-					__( 'Cannot deliver a feed that has not been completed.', 'woocommerce-product-feed-openai' )
-				)
-			);
-		}
-
-		// Temporary. There is no point in writing to the filesystem only to load the whole file into memory.
-		$data = json_decode( file_get_contents( $this->file_path ), true );
-		unlink( $this->file_path );
-		return $data;
 	}
 
 	/**

--- a/src/Utils/MemoryManager.php
+++ b/src/Utils/MemoryManager.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Memory Manager class.
+ *
+ * @package Automattic\WooCommerce\ProductFeedForOpenAI
+ */
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\ProductFeedForOpenAI\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Helper class for managing memory.
+ */
+class MemoryManager {
+	/**
+	 * Get available memory as a percentage of the total memory limit.
+	 *
+	 * @return int Available memory as a percentage of the total memory limit.
+	 */
+	public static function get_available_memory(): int {
+		$memory_limit = wp_convert_hr_to_bytes( ini_get( 'memory_limit' ) );
+		if ( -1 === $memory_limit ) {
+			// Some systems have "unlimited" memory.
+			// We should treat that as if there is none left.
+			return 0;
+		}
+		return (int) round( 100 - ( memory_get_usage( true ) / $memory_limit ) * 100 );
+	}
+
+	/**
+	 * Flush all caches caches.
+	 */
+	public static function flush_caches() {
+		global $wpdb, $wp_object_cache;
+
+		$wpdb->queries = [];
+
+		wp_cache_flush();
+
+		if ( ! is_object( $wp_object_cache ) ) {
+			return;
+		}
+
+		$wp_object_cache->group_ops      = [];
+		$wp_object_cache->stats          = [];
+		$wp_object_cache->memcache_debug = [];
+		$wp_object_cache->cache          = [];
+
+		// This method is specific to certain memcached implementations.
+		if ( method_exists( $wp_object_cache, '__remoteset' ) ) {
+			$wp_object_cache->__remoteset(); // important.
+		}
+
+		self::collect_garbage();
+	}
+
+	/**
+	 * Collect garbage.
+	 */
+	public static function collect_garbage() {
+		static $gc_threshold         = 5000;
+		static $gc_too_low_in_a_row  = 0;
+		static $gc_too_high_in_a_row = 0;
+
+		$gc_threshold_step = 2_500;
+		$gc_status         = gc_status();
+
+		if ( $gc_threshold > $gc_status['threshold'] ) {
+			// If PHP managed to collect memory in the meantime and established threshold lower than ours, just use theirs.
+			$gc_threshold = $gc_status['threshold'];
+		}
+
+		if ( $gc_status['roots'] > $gc_threshold ) {
+			$collected = gc_collect_cycles();
+			if ( $collected < 100 ) {
+				if ( $gc_too_low_in_a_row > 0 ) {
+					$gc_too_low_in_a_row = 0;
+					// Raise GC threshold if we collected too little twice in a row.
+					$gc_threshold += $gc_threshold_step;
+					$gc_threshold  = min( $gc_threshold, 1_000_000_000, $gc_status['threshold'] );
+				} else {
+					++$gc_too_low_in_a_row;
+				}
+				$gc_too_high_in_a_row = 0;
+			} else {
+				if ( $gc_too_high_in_a_row > 0 ) {
+					$gc_too_high_in_a_row = 0;
+					// Lower GC threshold if we collected more than enough twice in a row.
+					$gc_threshold -= $gc_threshold_step;
+					$gc_threshold  = max( $gc_threshold, 5_000 );
+				} else {
+					++$gc_too_high_in_a_row;
+				}
+				$gc_too_low_in_a_row = 0;
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description

Extracted optimization pieces from https://github.com/woocommerce/OpenAI-Product-Feed/pull/15.

See p1761204122338729-slack-C09EWAXSYD9. The main issue turned out to be within the product mapper, but those optimizations are still helpful with memory management.

# Testing instructions

Run this command and make sure you see some sort of a response:

```bash
wp product-feed generate --send --batch-size=10 --debug=E_ALL
```

In my case, I'm using a local server that receives the feed and I see a successful `WP_REST_Response`.

## Checklist

<!-- Mark completed items with an "x" -->

- [x] `npm run test:php` does not return errors.
- [x] `npm run lint:php` does not return errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Progress logs now show per-batch and per-item timing plus memory usage.
  * Introduced automatic memory management with periodic cache flushing during feed generation.

* **Performance Improvements**
  * Feed generation now writes/reads from disk to reduce runtime memory usage.
  * Batch reports include total time and per-batch memory/timing for clearer throughput visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->