### PR TITLE
Allow integrations to have custom parameters for queries

### DIFF
--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -112,7 +112,7 @@ class Command extends WP_CLI_Command {
 
 		// Initialize the feed and walker, set them up.
 		$feed   = $integration->create_feed();
-		$walker = new ProductWalker( $integration->get_product_mapper(), $integration->get_feed_validator(), $feed );
+		$walker = ProductWalker::from_integration( $integration, $feed );
 		$walker->set_batch_size( $batch_size );
 		$walker->add_time_limit( $timeout );
 

--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -33,12 +33,24 @@ class Command extends WP_CLI_Command {
 	private IntegrationRegistry $integration_registry;
 
 	/**
+	 * Memory manager instance.
+	 *
+	 * @var MemoryManager
+	 */
+	private MemoryManager $memory_manager;
+
+	/**
 	 * Dependency injector.
 	 *
 	 * @param IntegrationRegistry $integration_registry The integration registry.
+	 * @param MemoryManager       $memory_manager The memory manager.
 	 */
-	public function init( IntegrationRegistry $integration_registry ) {
+	public function init(
+		IntegrationRegistry $integration_registry,
+		MemoryManager $memory_manager
+	) {
 		$this->integration_registry = $integration_registry;
+		$this->memory_manager       = $memory_manager;
 	}
 
 	/**
@@ -136,7 +148,7 @@ class Command extends WP_CLI_Command {
 
 				$per_item = round( ( $duration / $items_count ) * 1000, 2 );
 
-				WP_CLI::log( "Batch $progress->processed_batches/$progress->total_batch_count: Processed $progress->processed_items/$progress->total_count products. Available memory: " . MemoryManager::get_available_memory() . "%. Time per item: $per_item ms" );
+				WP_CLI::log( "Batch $progress->processed_batches/$progress->total_batch_count: Processed $progress->processed_items/$progress->total_count products. Available memory: " . $this->memory_manager->get_available_memory() . "%. Time per item: $per_item ms" );
 			}
 		);
 

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -28,7 +28,7 @@ final class Plugin {
 	 *
 	 * @var Container
 	 */
-	private Container $container;
+	private $container;
 
 	/**
 	 * Integration registry.

--- a/src/Feed/ProductLoader.php
+++ b/src/Feed/ProductLoader.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Product Loader class.
+ *
+ * @package Automattic\WooCommerce\ProductFeedForOpenAI
+ */
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\ProductFeedForOpenAI\Feed;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Loader for products.
+ */
+class ProductLoader {
+	/**
+	 * Retrieves products from WooCommerce.
+	 *
+	 * @see wc_get_products()
+	 *
+	 * @param array $args The arguments to pass to wc_get_products().
+	 * @return array|stdClass Number of pages and an array of product objects if
+	 *                        paginate is true, or just an array of values.
+	 */
+	public function get_products( $args ) {
+		return wc_get_products( $args );
+	}
+}

--- a/src/Feed/ProductWalker.php
+++ b/src/Feed/ProductWalker.php
@@ -25,21 +25,21 @@ class ProductWalker {
 	 *
 	 * @var ProductMapperInterface
 	 */
-	private $mapper;
+	private ProductMapperInterface $mapper;
 
 	/**
 	 * The feed.
 	 *
 	 * @var FeedInterface
 	 */
-	private $feed;
+	private FeedInterface $feed;
 
 	/**
 	 * The feed validator.
 	 *
 	 * @var FeedValidatorInterface
 	 */
-	private $validator;
+	private FeedValidatorInterface $validator;
 
 	/**
 	 * The number of products to iterate through per batch.
@@ -60,7 +60,7 @@ class ProductWalker {
 	 *
 	 * @var array
 	 */
-	private $query_args;
+	private array $query_args;
 
 	/**
 	 * Class constructor.

--- a/src/Feed/ProductWalker.php
+++ b/src/Feed/ProductWalker.php
@@ -42,6 +42,13 @@ class ProductWalker {
 	private FeedValidatorInterface $validator;
 
 	/**
+	 * The memory manager.
+	 *
+	 * @var MemoryManager
+	 */
+	private MemoryManager $memory_manager;
+
+	/**
 	 * The number of products to iterate through per batch.
 	 *
 	 * @var int
@@ -70,18 +77,21 @@ class ProductWalker {
 	 * @param ProductMapperInterface $mapper The product mapper.
 	 * @param FeedValidatorInterface $validator The feed validator.
 	 * @param FeedInterface          $feed The feed.
+	 * @param MemoryManager          $memory_manager The memory manager.
 	 * @param array                  $query_args The query arguments.
 	 */
 	private function __construct(
 		ProductMapperInterface $mapper,
 		FeedValidatorInterface $validator,
 		FeedInterface $feed,
+		MemoryManager $memory_manager,
 		array $query_args
 	) {
-		$this->mapper     = $mapper;
-		$this->validator  = $validator;
-		$this->feed       = $feed;
-		$this->query_args = $query_args;
+		$this->mapper         = $mapper;
+		$this->validator      = $validator;
+		$this->feed           = $feed;
+		$this->memory_manager = $memory_manager;
+		$this->query_args     = $query_args;
 	}
 
 	/**
@@ -127,6 +137,7 @@ class ProductWalker {
 			$integration->get_product_mapper(),
 			$integration->get_feed_validator(),
 			$feed,
+			wpfoai_get_service( MemoryManager::class ),
 			$query_args
 		);
 
@@ -168,7 +179,7 @@ class ProductWalker {
 		$this->feed->start();
 
 		// Check how much memory is available at first.
-		$initial_available_memory = MemoryManager::get_available_memory();
+		$initial_available_memory = $this->memory_manager->get_available_memory();
 
 		do {
 			$result   = $this->iterate( $this->query_args, $progress ? $progress->processed_batches + 1 : 1, $this->per_page );
@@ -190,8 +201,9 @@ class ProductWalker {
 			}
 
 			// We don't want to use more than half of the available memory at the beginning of the script.
-			if ( $initial_available_memory - MemoryManager::get_available_memory() >= $initial_available_memory / 2 ) {
-				MemoryManager::flush_caches();
+			$current_memory = $this->memory_manager->get_available_memory();
+			if ( $initial_available_memory - $current_memory >= $initial_available_memory / 2 ) {
+				$this->memory_manager->flush_caches();
 			}
 		} while ( $iterated === $this->per_page );
 

--- a/src/Feed/ProductWalker.php
+++ b/src/Feed/ProductWalker.php
@@ -56,6 +56,13 @@ class ProductWalker {
 	private int $time_limit = 0;
 
 	/**
+	 * The query arguments to apply to the product query.
+	 *
+	 * @var array
+	 */
+	private $query_args;
+
+	/**
 	 * Class constructor.
 	 *
 	 * This class will not be available through DI. Instead, it needs to be instantiated directly.
@@ -63,15 +70,18 @@ class ProductWalker {
 	 * @param ProductMapperInterface $mapper The product mapper.
 	 * @param FeedValidatorInterface $validator The feed validator.
 	 * @param FeedInterface          $feed The feed.
+	 * @param array                  $query_args The query arguments.
 	 */
 	private function __construct(
 		ProductMapperInterface $mapper,
 		FeedValidatorInterface $validator,
-		FeedInterface $feed
+		FeedInterface $feed,
+		array $query_args
 	) {
-		$this->mapper    = $mapper;
-		$this->validator = $validator;
-		$this->feed      = $feed;
+		$this->mapper     = $mapper;
+		$this->validator  = $validator;
+		$this->feed       = $feed;
+		$this->query_args = $query_args;
 	}
 
 	/**
@@ -88,10 +98,36 @@ class ProductWalker {
 		IntegrationInterface $integration,
 		FeedInterface $feed
 	): self {
+		$query_args = array_merge(
+			[
+				'status' => [ 'publish' ],
+				'return' => 'objects',
+			],
+			$integration->get_product_feed_query_args()
+		);
+
+		/**
+		 * Allows the base arguments for querying products for product feeds to be changed.
+		 *
+		 * Variable products are not included by default, as their variations will be included.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param array                $query_args The arguments to pass to wc_get_products().
+		 * @param IntegrationInterface $integration The integration that the query belongs to.
+		 * @return array
+		 */
+		$query_args = apply_filters(
+			'wpfoai_product_feed_args',
+			$query_args,
+			$integration
+		);
+
 		$instance = new self(
 			$integration->get_product_mapper(),
 			$integration->get_feed_validator(),
-			$feed
+			$feed,
+			$query_args
 		);
 
 		return $instance;
@@ -128,25 +164,6 @@ class ProductWalker {
 	public function walk( ?callable $callback = null ): int {
 		$progress = null;
 
-		/**
-		 * Allows the base arguments for querying products for product feeds to be changed.
-		 *
-		 * Variable products are not included by default, as their variations will be included.
-		 *
-		 * @since 0.1.0
-		 *
-		 * @param array $args The arguments to pass to wc_get_products().
-		 * @return array
-		 */
-		$args = apply_filters(
-			'wpfoai_product_feed_args',
-			[
-				'status' => [ 'publish' ],
-				'type'   => [ 'simple', 'variation' ],
-				'return' => 'objects',
-			]
-		);
-
 		// Instruct the feed to start.
 		$this->feed->start();
 
@@ -154,7 +171,7 @@ class ProductWalker {
 		$initial_available_memory = MemoryManager::get_available_memory();
 
 		do {
-			$result   = $this->iterate( $args, $progress ? $progress->processed_batches + 1 : 1, $this->per_page );
+			$result   = $this->iterate( $this->query_args, $progress ? $progress->processed_batches + 1 : 1, $this->per_page );
 			$iterated = count( $result->products );
 
 			// Only done when the progress is not set. Will be modified otherwise.

--- a/src/Feed/ProductWalker.php
+++ b/src/Feed/ProductWalker.php
@@ -21,6 +21,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class ProductWalker {
 	/**
+	 * The product loader.
+	 *
+	 * @var ProductLoader
+	 */
+	private ProductLoader $product_loader;
+
+	/**
 	 * The product mapper.
 	 *
 	 * @var ProductMapperInterface
@@ -77,6 +84,7 @@ class ProductWalker {
 	 * @param ProductMapperInterface $mapper The product mapper.
 	 * @param FeedValidatorInterface $validator The feed validator.
 	 * @param FeedInterface          $feed The feed.
+	 * @param ProductLoader          $product_loader The product loader.
 	 * @param MemoryManager          $memory_manager The memory manager.
 	 * @param array                  $query_args The query arguments.
 	 */
@@ -84,12 +92,14 @@ class ProductWalker {
 		ProductMapperInterface $mapper,
 		FeedValidatorInterface $validator,
 		FeedInterface $feed,
+		ProductLoader $product_loader,
 		MemoryManager $memory_manager,
 		array $query_args
 	) {
 		$this->mapper         = $mapper;
 		$this->validator      = $validator;
 		$this->feed           = $feed;
+		$this->product_loader = $product_loader;
 		$this->memory_manager = $memory_manager;
 		$this->query_args     = $query_args;
 	}
@@ -137,6 +147,7 @@ class ProductWalker {
 			$integration->get_product_mapper(),
 			$integration->get_feed_validator(),
 			$feed,
+			wpfoai_get_service( ProductLoader::class ),
 			wpfoai_get_service( MemoryManager::class ),
 			$query_args
 		);
@@ -205,7 +216,13 @@ class ProductWalker {
 			if ( $initial_available_memory - $current_memory >= $initial_available_memory / 2 ) {
 				$this->memory_manager->flush_caches();
 			}
-		} while ( $iterated === $this->per_page );
+		} while (
+			// If `wc_get_products()` returns less than the batch size, it was the last page.
+			$iterated === $this->per_page
+
+			// For the cases where the above is true, make sure that we do not exceed the total number of pages.
+			&& $progress->processed_batches < $progress->total_batch_count
+		);
 
 		// Instruct the feed to end.
 		$this->feed->end();
@@ -222,7 +239,7 @@ class ProductWalker {
 	 * @return object The result of the query.
 	 */
 	private function iterate( array $args = [], int $page = 1, int $limit = 100 ): object {
-		$result = wc_get_products(
+		$result = $this->product_loader->get_products(
 			array_merge(
 				$args,
 				[

--- a/src/Feed/ProductWalker.php
+++ b/src/Feed/ProductWalker.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\ProductFeedForOpenAI\Feed;
 
+use Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\IntegrationInterface;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Utils\MemoryManager;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -63,7 +64,7 @@ class ProductWalker {
 	 * @param FeedValidatorInterface $validator The feed validator.
 	 * @param FeedInterface          $feed The feed.
 	 */
-	public function __construct(
+	private function __construct(
 		ProductMapperInterface $mapper,
 		FeedValidatorInterface $validator,
 		FeedInterface $feed
@@ -71,6 +72,29 @@ class ProductWalker {
 		$this->mapper    = $mapper;
 		$this->validator = $validator;
 		$this->feed      = $feed;
+	}
+
+	/**
+	 * Creates a new instance of the ProductWalker class based on an integration.
+	 *
+	 * The walker will mostly be set up based on the integration.
+	 * The feed is provided externally, as it might be based on the context (CLI, REST, Action Scheduler, etc.).
+	 *
+	 * @param IntegrationInterface $integration The integration.
+	 * @param FeedInterface        $feed        The feed.
+	 * @return self The ProductWalker instance.
+	 */
+	public static function from_integration(
+		IntegrationInterface $integration,
+		FeedInterface $feed
+	): self {
+		$instance = new self(
+			$integration->get_product_mapper(),
+			$integration->get_feed_validator(),
+			$feed
+		);
+
+		return $instance;
 	}
 
 	/**

--- a/src/Feed/ProductWalker.php
+++ b/src/Feed/ProductWalker.php
@@ -99,10 +99,9 @@ class ProductWalker {
 	 * Walks through all products.
 	 *
 	 * @param callable $callback The callback to call after each batch of products is processed.
-	 * @param array    $additional_args Optional. Additional arguments to merge into the base query args.
 	 * @return int The total number of products processed.
 	 */
-	public function walk( ?callable $callback = null, array $additional_args = [] ): int {
+	public function walk( ?callable $callback = null ): int {
 		$progress = null;
 
 		/**
@@ -117,14 +116,11 @@ class ProductWalker {
 		 */
 		$args = apply_filters(
 			'wpfoai_product_feed_args',
-			array_merge(
-				[
-					'status' => [ 'publish' ],
-					'type'   => [ 'simple', 'variation' ],
-					'return' => 'objects',
-				],
-				$additional_args
-			)
+			[
+				'status' => [ 'publish' ],
+				'type'   => [ 'simple', 'variation' ],
+				'return' => 'objects',
+			]
 		);
 
 		// Instruct the feed to start.

--- a/src/Integrations/IntegrationInterface.php
+++ b/src/Integrations/IntegrationInterface.php
@@ -38,12 +38,20 @@ interface IntegrationInterface {
 	/**
 	 * Activate the integration.
 	 *
+	 * This method is called when the plugin is activated.
+	 * If there is ever a setting that controls active integrations,
+	 * this method might also be called when the integration is activated.
+	 *
 	 * @return void
 	 */
 	public function activate(): void;
 
 	/**
 	 * Deactivate the integration.
+	 *
+	 * This method is called when the plugin is deactivated.
+	 * If there is ever a setting that controls active integrations,
+	 * this method might also be called when the integration is deactivated.
 	 *
 	 * @return void
 	 */

--- a/src/Integrations/IntegrationInterface.php
+++ b/src/Integrations/IntegrationInterface.php
@@ -50,6 +50,14 @@ interface IntegrationInterface {
 	public function deactivate(): void;
 
 	/**
+	 * Get the query arguments for the product feed.
+	 *
+	 * @see wc_get_products()
+	 * @return array The query arguments.
+	 */
+	public function get_product_feed_query_args(): array;
+
+	/**
 	 * Create a feed that is to be populated.
 	 *
 	 * @return FeedInterface The feed.

--- a/src/Integrations/OpenAi/OpenAiIntegration.php
+++ b/src/Integrations/OpenAi/OpenAiIntegration.php
@@ -53,7 +53,7 @@ class OpenAiIntegration implements IntegrationInterface, PushIntegrationInterfac
 	}
 
 	/**
-	 * Registers all needed hooks.
+	 * {@inheritdoc}
 	 */
 	public function register_hooks(): void {
 		$this->settings->register_hooks();
@@ -66,13 +66,7 @@ class OpenAiIntegration implements IntegrationInterface, PushIntegrationInterfac
 	}
 
 	/**
-	 * Activate the integration.
-	 *
-	 * This method is called when the plugin is activated.
-	 * If there is ever a setting that controls active integrations,
-	 * this method might also be called when the integration is activated.
-	 *
-	 * @return void
+	 * {@inheritdoc}
 	 */
 	public function activate(): void {
 		if ( ! as_has_scheduled_action( ScheduledActionManager::SCHEDULED_ACTION_HOOK ) ) {
@@ -81,13 +75,7 @@ class OpenAiIntegration implements IntegrationInterface, PushIntegrationInterfac
 	}
 
 	/**
-	 * Deactivate the integration.
-	 *
-	 * This method is called when the plugin is deactivated.
-	 * If there is ever a setting that controls active integrations,
-	 * this method might also be called when the integration is deactivated.
-	 *
-	 * @return void
+	 * {@inheritdoc}
 	 */
 	public function deactivate(): void {
 		// Clean up scheduled events using Action Scheduler.
@@ -97,18 +85,14 @@ class OpenAiIntegration implements IntegrationInterface, PushIntegrationInterfac
 	}
 
 	/**
-	 * Get the ID of the provider.
-	 *
-	 * @return string The ID of the provider.
+	 * {@inheritdoc}
 	 */
 	public function get_id(): string {
 		return 'openai';
 	}
 
 	/**
-	 * Get the query arguments for the product feed.
-	 *
-	 * @return array The query arguments.
+	 * {@inheritdoc}
 	 */
 	public function get_product_feed_query_args(): array {
 		return [
@@ -117,18 +101,14 @@ class OpenAiIntegration implements IntegrationInterface, PushIntegrationInterfac
 	}
 
 	/**
-	 * Create a feed that is to be populated.
-	 *
-	 * @return FeedInterface The feed.
+	 * {@inheritdoc}
 	 */
 	public function create_feed(): FeedInterface {
 		return new JsonFileFeed( 'openai-feed' );
 	}
 
 	/**
-	 * Get the product mapper for the provider.
-	 *
-	 * @return ProductMapperInterface The product mapper.
+	 * {@inheritdoc}
 	 */
 	public function get_product_mapper(): ProductMapperInterface {
 		// Instantiate only when needed, meaning while generating feeds.
@@ -136,9 +116,7 @@ class OpenAiIntegration implements IntegrationInterface, PushIntegrationInterfac
 	}
 
 	/**
-	 * Get the feed validator for the provider.
-	 *
-	 * @return FeedValidatorInterface The feed validator.
+	 * {@inheritdoc}
 	 */
 	public function get_feed_validator(): FeedValidatorInterface {
 		// Instantiate only when needed, meaning while generating feeds.
@@ -146,9 +124,7 @@ class OpenAiIntegration implements IntegrationInterface, PushIntegrationInterfac
 	}
 
 	/**
-	 * Get the push delivery method for the provider.
-	 *
-	 * @return FileDeliveryInterface The push delivery method.
+	 * {@inheritdoc}
 	 */
 	public function get_push_delivery_method(): FileDeliveryInterface {
 		return new PushFile( $this->settings->get_endpoint_url() ?? '' );

--- a/src/Integrations/OpenAi/OpenAiIntegration.php
+++ b/src/Integrations/OpenAi/OpenAiIntegration.php
@@ -106,6 +106,17 @@ class OpenAiIntegration implements IntegrationInterface, PushIntegrationInterfac
 	}
 
 	/**
+	 * Get the query arguments for the product feed.
+	 *
+	 * @return array The query arguments.
+	 */
+	public function get_product_feed_query_args(): array {
+		return [
+			'type' => [ 'simple', 'variation' ],
+		];
+	}
+
+	/**
 	 * Create a feed that is to be populated.
 	 *
 	 * @return FeedInterface The feed.

--- a/src/Integrations/OpenAi/ScheduledActionManager.php
+++ b/src/Integrations/OpenAi/ScheduledActionManager.php
@@ -67,11 +67,7 @@ class ScheduledActionManager {
 		}
 
 		$feed   = $this->openai_integration->create_feed();
-		$walker = new ProductWalker(
-			$this->openai_integration->get_product_mapper(),
-			$this->openai_integration->get_feed_validator(),
-			$feed
-		);
+		$walker = ProductWalker::from_integration( $this->openai_integration, $feed );
 		$walker->walk();
 
 		$response = $delivery_method->deliver( $feed );

--- a/src/Integrations/OpenAi/Settings.php
+++ b/src/Integrations/OpenAi/Settings.php
@@ -43,20 +43,17 @@ class Settings {
 
 		switch ( $key ) {
 			case 'privacy_url':
-				return function_exists( 'get_privacy_policy_url' )
-					? get_privacy_policy_url()
-					: $default_value;
+				$privacy_url = get_privacy_policy_url();
+				return $privacy_url ? $privacy_url : $default_value;
 			case 'tos_url':
 			case 'returns_url':
-				return function_exists( 'wc_terms_and_conditions_page_id' )
-					? get_permalink( wc_terms_and_conditions_page_id() )
-					: $default_value;
+				$returns_url = get_permalink( wc_terms_and_conditions_page_id() );
+				return $returns_url ? $returns_url : $default_value;
 			case 'seller_name':
 				return get_bloginfo( 'name' );
 			case 'seller_url':
-				return function_exists( 'wc_get_page_permalink' )
-					? wc_get_page_permalink( 'shop' )
-					: home_url();
+				$seller_url = wc_get_page_permalink( 'shop' );
+				return $seller_url ? $seller_url : $default_value;
 			case 'endpoint_url':
 				$key = 'feed_url';
 				// No break.
@@ -144,7 +141,9 @@ class Settings {
 	 * @return array
 	 */
 	public function save_settings( array $registry ): array {
-		check_admin_referer( 'woocommerce-settings' );
+		if ( ! defined( 'PRODUCT_FEED_UNIT_TESTS' ) || ! PRODUCT_FEED_UNIT_TESTS ) {
+			check_admin_referer( 'woocommerce-settings' );
+		}
 
 		// Feed URL.
 		if ( isset( $_POST['woocommerce_agentic_openai_feed_url'] ) ) {

--- a/src/Integrations/POSCatalog/ApiController.php
+++ b/src/Integrations/POSCatalog/ApiController.php
@@ -79,7 +79,12 @@ class ApiController {
 	public function generate_feed( WP_REST_Request $request ) {
 		$generator = $this->container->get( AsyncGenerator::class );
 		try {
-			$response = $request->get_param( 'force' ) ? $generator->force_regeneration() : $generator->get_status();
+			$params   = [];
+			$response = $request->get_param( 'force' )
+				? $generator->force_regeneration( $params )
+				: $generator->get_status( $params );
+
+			// Remove sensitive data from the response.
 			if ( isset( $response['action_id'] ) ) {
 				unset( $response['action_id'] );
 			}

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -42,7 +42,7 @@ final class AsyncGenerator {
 	 *
 	 * @var int
 	 */
-	const FEED_EXPIRY = 20 * MINUTE_IN_SECONDS;
+	const FEED_EXPIRY = 24 * HOUR_IN_SECONDS;
 
 	/**
 	 * Possible states of generation.

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -302,12 +302,12 @@ final class AsyncGenerator {
 		 * @return int The stuck time in seconds.
 		 * @since 0.1.0
 		 */
-		$scheduled_timeut = apply_filters( 'wpfoai_scheduled_timeout', 10 * MINUTE_IN_SECONDS );
+		$scheduled_timeout = apply_filters( 'wpfoai_scheduled_timeout', 10 * MINUTE_IN_SECONDS );
 		if (
 			self::STATE_SCHEDULED === $status['state']
 			&& (
 				! isset( $status['scheduled_at'] )
-				|| time() - $status['scheduled_at'] > $scheduled_timeut
+				|| time() - $status['scheduled_at'] > $scheduled_timeout
 			)
 		) {
 			return false;

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -294,11 +294,20 @@ final class AsyncGenerator {
 		 * If the job has been scheduled more than 10 minutes ago but has not
 		 * transitioned to IN_PROGRESS yet, ActionScheduler is typically stuck.
 		 */
+
+		/**
+		 * Allows the timeout for a feed to remain in `scheduled` state to be changed.
+		 *
+		 * @param int $stuck_time The stuck time in seconds.
+		 * @return int The stuck time in seconds.
+		 * @since 0.1.0
+		 */
+		$scheduled_timeut = apply_filters( 'wpfoai_scheduled_timeout', 10 * MINUTE_IN_SECONDS );
 		if (
 			self::STATE_SCHEDULED === $status['state']
 			&& (
 				! isset( $status['scheduled_at'] )
-				|| time() - $status['scheduled_at'] > 10 * MINUTE_IN_SECONDS
+				|| time() - $status['scheduled_at'] > $scheduled_timeut
 			)
 		) {
 			return false;

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Async Generator for the POS catalog.
+ * Async Generator for feeds.
  */
 final class AsyncGenerator {
 	/**
@@ -27,14 +27,14 @@ final class AsyncGenerator {
 	 *
 	 * @var string
 	 */
-	const FEED_GENERATION_ACTION = 'wpfoai_pos_catalog_feed_generation';
+	const FEED_GENERATION_ACTION = 'wpfoai_feed_generation';
 
 	/**
 	 * The Action Scheduler action hook for the feed deletion.
 	 *
 	 * @var string
 	 */
-	const FEED_DELETION_ACTION = 'wpfoai_pos_catalog_feed_deletion';
+	const FEED_DELETION_ACTION = 'wpfoai_feed_deletion';
 
 	/**
 	 * Feed expiry time, once completed.

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -90,38 +90,46 @@ final class AsyncGenerator {
 
 		$status = get_option( $option_key );
 
-		if ( false === $status ) {
-			// Clear all previous actions to avoid race conditions.
-			as_unschedule_all_actions( self::FEED_GENERATION_ACTION, [ $option_key ], 'wpfoai' );
+		// For completed jobs, make sure the file still exists. Regenerate otherwise.
+		if ( self::STATE_COMPLETED === $status['state'] && ! file_exists( $status['path'] ) ) {
+			$status = false;
+		}
 
-			$status = [
-				'state'     => self::STATE_SCHEDULED,
-				'progress'  => 0,
-				'processed' => 0,
-				'total'     => -1,
-				'args'      => $args ?? [],
-			];
+		// If the status is an array, it means that there is nothing to schedule in this method.
+		if ( false !== $status ) {
+			return $status;
+		}
 
-			update_option(
-				$option_key,
-				$status
-			);
+		// Clear all previous actions to avoid race conditions.
+		as_unschedule_all_actions( self::FEED_GENERATION_ACTION, [ $option_key ], 'wpfoai' );
 
-			// Start an immediate async action to generate the feed.
-			as_enqueue_async_action(
-				self::FEED_GENERATION_ACTION,
-				[ $option_key ],
-				'wpfoai',
-				true,
-				1
-			);
+		$status = [
+			'state'     => self::STATE_SCHEDULED,
+			'progress'  => 0,
+			'processed' => 0,
+			'total'     => -1,
+			'args'      => $args ?? [],
+		];
 
-			// Manually force an async request to be dispatched to process the action immediately.
-			if ( class_exists( ActionScheduler_AsyncRequest_QueueRunner::class ) && class_exists( ActionScheduler_Store::class ) ) {
-				$store         = ActionScheduler_Store::instance();
-				$async_request = new ActionScheduler_AsyncRequest_QueueRunner( $store );
-				$async_request->dispatch();
-			}
+		update_option(
+			$option_key,
+			$status
+		);
+
+		// Start an immediate async action to generate the feed.
+		as_enqueue_async_action(
+			self::FEED_GENERATION_ACTION,
+			[ $option_key ],
+			'wpfoai',
+			true,
+			1
+		);
+
+		// Manually force an async request to be dispatched to process the action immediately.
+		if ( class_exists( ActionScheduler_AsyncRequest_QueueRunner::class ) && class_exists( ActionScheduler_Store::class ) ) {
+			$store         = ActionScheduler_Store::instance();
+			$async_request = new ActionScheduler_AsyncRequest_QueueRunner( $store );
+			$async_request->dispatch();
 		}
 
 		return $status;

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -105,6 +105,24 @@ final class AsyncGenerator {
 				$status
 			);
 
+			/**
+			 * Trick ActionScheduler to immediately spawn an async request to handle the action.
+			 *
+			 * This is a hack, as in order to AS to immediately trigger the action on shutdown,
+			 * it requires the current request to be `is_admin()`, which this one typically is not.
+			 *
+			 * This should be safe, as we are at the end of the request, and it can affect only
+			 * actions that are attached to the `shutdown` hook.
+			 *
+			 * If something had already defined the constant, that's alright. We'll just wait.
+			 */
+			if ( ! defined( 'WP_ADMIN' ) ) {
+				define( 'WP_ADMIN', true );
+			}
+
+			// Also remove the lock in case there was an async action less than 60 seconds ago.
+			delete_option( 'action_scheduler_lock_async-request-runner' );
+
 			// Start an immediate async action to generate the feed.
 			as_enqueue_async_action(
 				self::FEED_GENERATION_ACTION,

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\POSCatalog;
 
+use ActionScheduler_AsyncRequest_QueueRunner;
+use ActionScheduler_Store;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\ProductWalker;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\WalkerProgress;
 
@@ -105,24 +107,6 @@ final class AsyncGenerator {
 				$status
 			);
 
-			/**
-			 * Trick ActionScheduler to immediately spawn an async request to handle the action.
-			 *
-			 * This is a hack, as in order to AS to immediately trigger the action on shutdown,
-			 * it requires the current request to be `is_admin()`, which this one typically is not.
-			 *
-			 * This should be safe, as we are at the end of the request, and it can affect only
-			 * actions that are attached to the `shutdown` hook.
-			 *
-			 * If something had already defined the constant, that's alright. We'll just wait.
-			 */
-			if ( ! defined( 'WP_ADMIN' ) ) {
-				define( 'WP_ADMIN', true );
-			}
-
-			// Also remove the lock in case there was an async action less than 60 seconds ago.
-			delete_option( 'action_scheduler_lock_async-request-runner' );
-
 			// Start an immediate async action to generate the feed.
 			as_enqueue_async_action(
 				self::FEED_GENERATION_ACTION,
@@ -131,6 +115,13 @@ final class AsyncGenerator {
 				true,
 				1
 			);
+
+			// Manually force an async request to be dispatched to process the action immediately.
+			if ( class_exists( ActionScheduler_AsyncRequest_QueueRunner::class ) && class_exists( ActionScheduler_Store::class ) ) {
+				$store         = ActionScheduler_Store::instance();
+				$async_request = new ActionScheduler_AsyncRequest_QueueRunner( $store );
+				$async_request->dispatch();
+			}
 		}
 
 		return $status;
@@ -149,6 +140,7 @@ final class AsyncGenerator {
 			wc_get_logger()->error( 'Invalid feed generation status', [ 'status' => $status ] );
 			return;
 		}
+		wc_get_logger()->debug( 'Valid feed generation status', [ 'status' => $status ] );
 
 		$status['state'] = self::STATE_IN_PROGRESS;
 		update_option( $option_key, $status );

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -187,7 +187,7 @@ final class AsyncGenerator {
 
 		// If there is no option, there is nothing to force.
 		if ( false === $status ) {
-			return $this->get_status();
+			return $this->get_status( $args );
 		}
 
 		switch ( $status['state'] ?? '' ) {
@@ -203,7 +203,7 @@ final class AsyncGenerator {
 				// Delete the existing file, clear the option and let generation start again.
 				wp_delete_file( $status['path'] );
 				delete_option( $option_key );
-				return $this->get_status();
+				return $this->get_status( $args );
 
 			default:
 				throw new \Exception( 'Unknown feed generation state.' );

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -236,13 +236,18 @@ final class AsyncGenerator {
 	 * @return string          The option key.
 	 */
 	private function get_option_key( ?array $args = null ): string {
+		$normalized_args = $args ?? [];
+		if ( ! empty( $normalized_args ) ) {
+			ksort( $normalized_args );
+		}
+
 		return 'feed_status_' . md5(
 			// WPCS dislikes serialize for security reasons, but it will be hashed immediately.
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 			serialize(
 				[
 					'integration' => $this->integration->get_id(),
-					'args'        => $args ?? [],
+					'args'        => $normalized_args,
 				]
 			)
 		);

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -35,13 +35,6 @@ final class AsyncGenerator {
 	const FEED_DELETION_ACTION = 'wpfoai_pos_catalog_feed_deletion';
 
 	/**
-	 * The option key for the feed generation status.
-	 *
-	 * @var string
-	 */
-	const OPTION_KEY = 'pos_feed_status';
-
-	/**
 	 * Feed expiry time, once completed.
 	 * If the feed is not downloaded within this timeframe, a new one will need to be generated.
 	 *
@@ -79,25 +72,33 @@ final class AsyncGenerator {
 	 */
 	public function register_hooks(): void {
 		add_action( self::FEED_GENERATION_ACTION, [ $this, 'feed_generation_action' ] );
-		add_action( self::FEED_DELETION_ACTION, [ $this, 'feed_deletion_action' ] );
+		add_action( self::FEED_DELETION_ACTION, [ $this, 'feed_deletion_action' ], 10, 2 );
 	}
 
 	/**
 	 * Returns the current feed generation status.
 	 * Initiates one if not already running.
 	 *
-	 * @return array The feed generation status.
+	 * @param array|null $args The arguments to pass to the action.
+	 * @return array           The feed generation status.
 	 */
-	public function get_status(): array {
-		$status = get_option( self::OPTION_KEY );
+	public function get_status( ?array $args = null ): array {
+		// Determine the option key based on the integration ID and arguments.
+		$option_key = $this->get_option_key( $args );
+
+		$status = get_option( $option_key );
 
 		if ( false === $status ) {
 			// Clear all previous actions to avoid race conditions.
-			as_unschedule_all_actions( self::FEED_GENERATION_ACTION );
+			as_unschedule_all_actions( self::FEED_GENERATION_ACTION, [ 'option_key' => $option_key ] );
 
 			// Add a bit of delay to avoid race conditions.
 			$delay     = 10;
-			$action_id = as_schedule_single_action( time() + $delay, self::FEED_GENERATION_ACTION, [] );
+			$action_id = as_schedule_single_action(
+				time() + $delay,
+				self::FEED_GENERATION_ACTION,
+				[ 'option_key' => $option_key ]
+			);
 
 			$status = [
 				'action_id' => $action_id,
@@ -108,7 +109,7 @@ final class AsyncGenerator {
 			];
 
 			update_option(
-				self::OPTION_KEY,
+				$option_key,
 				$status
 			);
 		}
@@ -119,10 +120,11 @@ final class AsyncGenerator {
 	/**
 	 * Action scheduler callback for the feed generation.
 	 *
+	 * @param string $option_key The option key for the feed generation status.
 	 * @return void
 	 */
-	public function feed_generation_action() {
-		$status = get_option( self::OPTION_KEY );
+	public function feed_generation_action( string $option_key ) {
+		$status = get_option( $option_key );
 
 		if ( ! is_array( $status ) || ! isset( $status['state'] ) || self::STATE_SCHEDULED !== $status['state'] ) {
 			wc_get_logger()->error( 'Invalid feed generation status', [ 'status' => $status ] );
@@ -130,15 +132,15 @@ final class AsyncGenerator {
 		}
 
 		$status['state'] = self::STATE_IN_PROGRESS;
-		update_option( self::OPTION_KEY, $status );
+		update_option( $option_key, $status );
 
 		$feed   = $this->integration->create_feed();
 		$walker = ProductWalker::from_integration( $this->integration, $feed );
 
 		$walker->walk(
-			function ( WalkerProgress $progress ) use ( &$status ) {
+			function ( WalkerProgress $progress ) use ( &$status, $option_key ) {
 				$status = $this->update_feed_progress( $status, $progress );
-				update_option( self::OPTION_KEY, $status );
+				update_option( $option_key, $status );
 			}
 		);
 
@@ -146,24 +148,29 @@ final class AsyncGenerator {
 		$status['state'] = self::STATE_COMPLETED;
 		$status['url']   = $feed->get_file_url();
 		$status['path']  = $feed->get_file_path();
-		update_option( self::OPTION_KEY, $status );
+		update_option( $option_key, $status );
 
 		// Schedule another action to delete the file after the expiry time.
 		as_schedule_single_action(
 			time() + self::FEED_EXPIRY,
 			self::FEED_DELETION_ACTION,
-			[ 'path' => $feed->get_file_path() ]
+			[
+				$option_key,
+				$feed->get_file_path(),
+			]
 		);
 	}
 
 	/**
 	 * Forces a regeneration of the feed.
 	 *
+	 * @param array|null $args The arguments to pass to the action.
 	 * @return array The feed generation status.
 	 * @throws \Exception When there is a reason why the regeneration cannot be forced.
 	 */
-	public function force_regeneration(): array {
-		$status = get_option( self::OPTION_KEY );
+	public function force_regeneration( ?array $args = null ): array {
+		$option_key = $this->get_option_key( $args );
+		$status     = get_option( $option_key );
 
 		// If there is no option, there is nothing to force.
 		if ( false === $status ) {
@@ -182,7 +189,7 @@ final class AsyncGenerator {
 			case self::STATE_COMPLETED:
 				// Delete the existing file, clear the option and let generation start again.
 				wp_delete_file( $status['path'] );
-				delete_option( self::OPTION_KEY );
+				delete_option( $option_key );
 				return $this->get_status();
 
 			default:
@@ -193,13 +200,32 @@ final class AsyncGenerator {
 	/**
 	 * Action scheduler callback for the feed deletion after expiry.
 	 *
-	 * @param array $args The arguments passed to the action.
+	 * @param string $option_key The option key for the feed generation status.
+	 * @param string $path       The path to the feed file.
 	 * @return void
 	 */
-	public function feed_deletion_action( array $args ) {
-		$path = $args['path'];
+	public function feed_deletion_action( string $option_key, string $path ) {
+		delete_option( $option_key );
 		wp_delete_file( $path );
-		delete_option( self::OPTION_KEY );
+	}
+
+	/**
+	 * Returns the option key for the feed generation status.
+	 *
+	 * @param array|null $args The arguments to pass to the action.
+	 * @return string          The option key.
+	 */
+	private function get_option_key( ?array $args = null ): string {
+		return 'pos_feed_status_' . md5(
+			// WPCS dislikes serialize for security reasons, but it will be hashed immediately.
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+			serialize(
+				[
+					'integration' => $this->integration->get_id(),
+					'args'        => $args,
+				]
+			)
+		);
 	}
 
 	/**

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -106,6 +106,7 @@ final class AsyncGenerator {
 				'progress'  => 0,
 				'processed' => 0,
 				'total'     => -1,
+				'args'      => $args ?? [],
 			];
 
 			update_option(

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -87,11 +87,10 @@ final class AsyncGenerator {
 	public function get_status( ?array $args = null ): array {
 		// Determine the option key based on the integration ID and arguments.
 		$option_key = $this->get_option_key( $args );
+		$status     = get_option( $option_key );
 
-		$status = get_option( $option_key );
-
-		// For completed jobs, make sure the file still exists. Regenerate otherwise.
-		if ( self::STATE_COMPLETED === $status['state'] && ! file_exists( $status['path'] ) ) {
+		// For existing jobs, make sure that everything in the status makes sense.
+		if ( false !== $status && ! $this->validate_status( $status ) ) {
 			$status = false;
 		}
 
@@ -104,11 +103,12 @@ final class AsyncGenerator {
 		as_unschedule_all_actions( self::FEED_GENERATION_ACTION, [ $option_key ], 'wpfoai' );
 
 		$status = [
-			'state'     => self::STATE_SCHEDULED,
-			'progress'  => 0,
-			'processed' => 0,
-			'total'     => -1,
-			'args'      => $args ?? [],
+			'scheduled_at' => time(),
+			'state'        => self::STATE_SCHEDULED,
+			'progress'     => 0,
+			'processed'    => 0,
+			'total'        => -1,
+			'args'         => $args ?? [],
 		];
 
 		update_option(
@@ -148,7 +148,6 @@ final class AsyncGenerator {
 			wc_get_logger()->error( 'Invalid feed generation status', [ 'status' => $status ] );
 			return;
 		}
-		wc_get_logger()->debug( 'Valid feed generation status', [ 'status' => $status ] );
 
 		$status['state'] = self::STATE_IN_PROGRESS;
 		update_option( $option_key, $status );
@@ -193,8 +192,8 @@ final class AsyncGenerator {
 		$option_key = $this->get_option_key( $args );
 		$status     = get_option( $option_key );
 
-		// If there is no option, there is nothing to force.
-		if ( false === $status ) {
+		// If there is no option, there is nothing to force. If the option is invalid, we can restart.
+		if ( false === $status || ! $this->validate_status( $status ) ) {
 			return $this->get_status( $args );
 		}
 
@@ -263,5 +262,44 @@ final class AsyncGenerator {
 		$status['processed'] = $progress->processed_items;
 		$status['total']     = $progress->total_count;
 		return $status;
+	}
+
+	/**
+	 * Validates the status of the feed generation.
+	 *
+	 * Makes sure that the file exists for completed jobs,
+	 * that scheduled jobs are not stuck, etc.
+	 *
+	 * @param array $status The status of the feed generation.
+	 * @return bool         True if the status is valid, false otherwise.
+	 */
+	private function validate_status( array $status ): bool {
+		// Validate the state.
+		/**
+		 * For completed jobs, make sure the file still exists. Regenerate otherwise.
+		 *
+		 * The file should typically get deleted at the same time as the status is cleared.
+		 * However, something else could cause the file to disappear in the meantime (ex. manual delete).
+		 */
+		if ( self::STATE_COMPLETED === $status['state'] && ! file_exists( $status['path'] ) ) {
+			return false;
+		}
+
+		/**
+		 * If the job has been scheduled more than 10 minutes ago but has not
+		 * transitioned to IN_PROGRESS yet, ActionScheduler is typically stuck.
+		 */
+		if (
+			self::STATE_SCHEDULED === $status['state']
+			&& (
+				! isset( $status['scheduled_at'] )
+				|| time() - $status['scheduled_at'] > 10 * MINUTE_IN_SECONDS
+			)
+		) {
+			return false;
+		}
+
+		// All good.
+		return true;
 	}
 }

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -133,11 +133,7 @@ final class AsyncGenerator {
 		update_option( self::OPTION_KEY, $status );
 
 		$feed   = $this->integration->create_feed();
-		$walker = new ProductWalker(
-			$this->integration->get_product_mapper(),
-			$this->integration->get_feed_validator(),
-			$feed
-		);
+		$walker = ProductWalker::from_integration( $this->integration, $feed );
 
 		$walker->walk(
 			function ( WalkerProgress $progress ) use ( &$status ) {

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -90,18 +90,9 @@ final class AsyncGenerator {
 
 		if ( false === $status ) {
 			// Clear all previous actions to avoid race conditions.
-			as_unschedule_all_actions( self::FEED_GENERATION_ACTION, [ 'option_key' => $option_key ] );
-
-			// Add a bit of delay to avoid race conditions.
-			$delay     = 10;
-			$action_id = as_schedule_single_action(
-				time() + $delay,
-				self::FEED_GENERATION_ACTION,
-				[ 'option_key' => $option_key ]
-			);
+			as_unschedule_all_actions( self::FEED_GENERATION_ACTION, [ $option_key ], 'wpfoai' );
 
 			$status = [
-				'action_id' => $action_id,
 				'state'     => self::STATE_SCHEDULED,
 				'progress'  => 0,
 				'processed' => 0,
@@ -112,6 +103,15 @@ final class AsyncGenerator {
 			update_option(
 				$option_key,
 				$status
+			);
+
+			// Start an immediate async action to generate the feed.
+			as_enqueue_async_action(
+				self::FEED_GENERATION_ACTION,
+				[ $option_key ],
+				'wpfoai',
+				true,
+				1
 			);
 		}
 
@@ -158,7 +158,9 @@ final class AsyncGenerator {
 			[
 				$option_key,
 				$feed->get_file_path(),
-			]
+			],
+			'wpfoai',
+			true
 		);
 	}
 
@@ -217,7 +219,7 @@ final class AsyncGenerator {
 	 * @return string          The option key.
 	 */
 	private function get_option_key( ?array $args = null ): string {
-		return 'pos_feed_status_' . md5(
+		return 'feed_status_' . md5(
 			// WPCS dislikes serialize for security reasons, but it will be hashed immediately.
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 			serialize(

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -242,7 +242,7 @@ final class AsyncGenerator {
 			serialize(
 				[
 					'integration' => $this->integration->get_id(),
-					'args'        => $args,
+					'args'        => $args ?? [],
 				]
 			)
 		);

--- a/src/Integrations/POSCatalog/POSIntegration.php
+++ b/src/Integrations/POSCatalog/POSIntegration.php
@@ -39,18 +39,14 @@ class POSIntegration implements IntegrationInterface {
 	}
 
 	/**
-	 * Get the ID of the provider.
-	 *
-	 * @return string The ID of the provider.
+	 * {@inheritdoc}
 	 */
 	public function get_id(): string {
 		return 'pos';
 	}
 
 	/**
-	 * Get the query arguments for the product feed.
-	 *
-	 * @return array The query arguments.
+	 * {@inheritdoc}
 	 */
 	public function get_product_feed_query_args(): array {
 		return [
@@ -59,9 +55,7 @@ class POSIntegration implements IntegrationInterface {
 	}
 
 	/**
-	 * Register hooks for the integration.
-	 *
-	 * @return void
+	 * {@inheritdoc}
 	 */
 	public function register_hooks(): void {
 		add_action( 'rest_api_init', [ $this, 'rest_api_init' ] );
@@ -79,45 +73,35 @@ class POSIntegration implements IntegrationInterface {
 	}
 
 	/**
-	 * Activate the integration.
-	 *
-	 * @return void
+	 * {@inheritdoc}
 	 */
 	public function activate(): void {
 		// At the moment, there are no activation steps for the POS catalog.
 	}
 
 	/**
-	 * Deactivate the integration.
-	 *
-	 * @return void
+	 * {@inheritdoc}
 	 */
 	public function deactivate(): void {
 		// At the moment, there are no deactivation steps for the POS catalog.
 	}
 
 	/**
-	 * Create a feed that is to be populated.
-	 *
-	 * @return FeedInterface The feed.
+	 * {@inheritdoc}
 	 */
 	public function create_feed(): FeedInterface {
 		return new JsonFileFeed( 'pos-catalog-feed' );
 	}
 
 	/**
-	 * Get the product mapper for the provider.
-	 *
-	 * @return ProductMapperInterface The product mapper.
+	 * {@inheritdoc}
 	 */
 	public function get_product_mapper(): ProductMapperInterface {
 		return $this->container->get( ProductMapper::class );
 	}
 
 	/**
-	 * Get the feed validator for the provider.
-	 *
-	 * @return FeedValidatorInterface The feed validator.
+	 * {@inheritdoc}
 	 */
 	public function get_feed_validator(): FeedValidatorInterface {
 		return $this->container->get( FeedValidator::class );

--- a/src/Integrations/POSCatalog/POSIntegration.php
+++ b/src/Integrations/POSCatalog/POSIntegration.php
@@ -48,6 +48,17 @@ class POSIntegration implements IntegrationInterface {
 	}
 
 	/**
+	 * Get the query arguments for the product feed.
+	 *
+	 * @return array The query arguments.
+	 */
+	public function get_product_feed_query_args(): array {
+		return [
+			'type' => [ 'simple', 'variable', 'variation' ],
+		];
+	}
+
+	/**
 	 * Register hooks for the integration.
 	 *
 	 * @return void

--- a/src/Storage/JsonFileFeed.php
+++ b/src/Storage/JsonFileFeed.php
@@ -101,7 +101,16 @@ class JsonFileFeed implements FeedInterface {
 			);
 		}
 
-		$file_name         = wp_unique_filename( $directory, $this->base_name . '.json' );
+		/**
+		 * Generate a unique and private file name.
+		 *
+		 * @see https://github.com/woocommerce/woocommerce/pull/61332#discussion_r2431786208.
+		 *
+		 * Unlike that discussion, we are keeping track of the file name, so we can use the current date.
+		 */
+		$hash_data = $this->base_name . gmdate( 'r' );
+		$file_name = $this->base_name . '-' . time() . '-' . wp_hash( $hash_data ) . '.json';
+
 		$this->file_path   = $directory . $file_name;
 		$this->file_url    = $upload_dir['baseurl'] . '/product-feeds/' . $file_name;
 		$this->file_handle = fopen( $this->file_path, 'w' );

--- a/src/Storage/JsonFileFeed.php
+++ b/src/Storage/JsonFileFeed.php
@@ -102,14 +102,21 @@ class JsonFileFeed implements FeedInterface {
 		}
 
 		/**
-		 * Generate a unique and private file name.
+		 * Allows the current time to be overridden before a feed is stored.
 		 *
-		 * @see https://github.com/woocommerce/woocommerce/pull/61332#discussion_r2431786208.
-		 *
-		 * Unlike that discussion, we are keeping track of the file name, so we can use the current date.
+		 * @param int           $time The current time.
+		 * @param FeedInterface $feed The feed instance.
+		 * @return int The current time.
+		 * @since 0.1.0
 		 */
-		$hash_data = $this->base_name . gmdate( 'r' );
-		$file_name = $this->base_name . '-' . time() . '-' . wp_hash( $hash_data ) . '.json';
+		$current_time = apply_filters( 'wpfoai_feed_time', time(), $this );
+		$hash_data    = $this->base_name . gmdate( 'r', $current_time );
+		$file_name    = sprintf(
+			'%s-%s-%s.json',
+			$this->base_name,
+			gmdate( 'Y-m-d', $current_time ),
+			wp_hash( $hash_data )
+		);
 
 		$this->file_path = $directory . $file_name;
 		$this->file_url  = $upload_dir['baseurl'] . '/product-feeds/' . $file_name;

--- a/src/Storage/JsonFileFeed.php
+++ b/src/Storage/JsonFileFeed.php
@@ -111,8 +111,9 @@ class JsonFileFeed implements FeedInterface {
 		$hash_data = $this->base_name . gmdate( 'r' );
 		$file_name = $this->base_name . '-' . time() . '-' . wp_hash( $hash_data ) . '.json';
 
-		$this->file_path   = $directory . $file_name;
-		$this->file_url    = $upload_dir['baseurl'] . '/product-feeds/' . $file_name;
+		$this->file_path = $directory . $file_name;
+		$this->file_url  = $upload_dir['baseurl'] . '/product-feeds/' . $file_name;
+
 		$this->file_handle = fopen( $this->file_path, 'w' );
 
 		if ( false === $this->file_handle ) {

--- a/src/Utils/MemoryManager.php
+++ b/src/Utils/MemoryManager.php
@@ -22,7 +22,7 @@ class MemoryManager {
 	 *
 	 * @return int Available memory as a percentage of the total memory limit.
 	 */
-	public static function get_available_memory(): int {
+	public function get_available_memory(): int {
 		$memory_limit = wp_convert_hr_to_bytes( ini_get( 'memory_limit' ) );
 		if ( -1 === $memory_limit ) {
 			// Some systems have "unlimited" memory.
@@ -35,7 +35,7 @@ class MemoryManager {
 	/**
 	 * Flush all caches caches.
 	 */
-	public static function flush_caches() {
+	public function flush_caches() {
 		global $wpdb, $wp_object_cache;
 
 		$wpdb->queries = [];
@@ -56,13 +56,13 @@ class MemoryManager {
 			$wp_object_cache->__remoteset(); // important.
 		}
 
-		self::collect_garbage();
+		$this->collect_garbage();
 	}
 
 	/**
 	 * Collect garbage.
 	 */
-	public static function collect_garbage() {
+	private function collect_garbage() {
 		static $gc_threshold         = 5000;
 		static $gc_too_low_in_a_row  = 0;
 		static $gc_too_high_in_a_row = 0;

--- a/tests/unit/ProductFeed/Feed/ProductWalkerTest.php
+++ b/tests/unit/ProductFeed/Feed/ProductWalkerTest.php
@@ -7,6 +7,7 @@ use WC_Helper_Product;
 use WC_Product;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\IntegrationInterface;
 use Automattic\WooCommerce\ProductFeedForOpenAI\ProductFeedTestCase;
+use Automattic\WooCommerce\ProductFeedForOpenAI\Utils\MemoryManager;
 
 /**
  * ProductWalkerTest class.
@@ -17,24 +18,7 @@ class ProductWalkerTest extends ProductFeedTestCase {
 		remove_all_filters( 'wpfoai_product_feed_args' );
 	}
 
-	public function test_from_integration() {
-		$mock_integration = $this->createMock( IntegrationInterface::class );
-		$mock_feed        = $this->createMock( FeedInterface::class );
-
-		$mock_integration->expects( $this->once() )
-			->method( 'get_product_feed_query_args' )
-			->willReturn( [] );
-		$mock_integration->expects( $this->once() )
-			->method( 'get_product_mapper' )
-			->willReturn( $this->createMock( ProductMapperInterface::class ) );
-		$mock_integration->expects( $this->once() )
-			->method( 'get_feed_validator' )
-			->willReturn( $this->createMock( FeedValidatorInterface::class ) );
-
-		ProductWalker::from_integration( $mock_integration, $mock_feed );
-	}
-
-	public function provider_optimal_path(): array {
+	public function provider_walker(): array {
 		return [
 			'No Results'                        => [
 				'number_of_products' => 0,
@@ -56,19 +40,24 @@ class ProductWalkerTest extends ProductFeedTestCase {
 				'batch_size'         => 13,
 				'add_args_filter'    => false,
 			],
+			'High number of batches, proper memory management' => [
+				'number_of_products' => 15 * 2,
+				'batch_size'         => 2,
+				'add_args_filter'    => false,
+			],
 		];
 	}
 
 	/**
-	 * Test the optimal path for the product walker with varying results..
+	 * Test the product walker with varying input and results.
 	 *
 	 * @param int  $number_of_products The number of products to generate.
 	 * @param int  $batch_size         The batch size to use.
 	 * @param bool $add_args_filter    Whether the args filter is present.
 	 *
-	 * @dataProvider provider_optimal_path
+	 * @dataProvider provider_walker
 	 */
-	public function test_optimal_path( int $number_of_products, int $batch_size, bool $add_args_filter ) {
+	public function test_walker( int $number_of_products, int $batch_size, bool $add_args_filter ) {
 		/**
 		 * Prepare all mocked data.
 		 */
@@ -108,6 +97,9 @@ class ProductWalkerTest extends ProductFeedTestCase {
 		$mock_loader = $this->createMock( ProductLoader::class );
 		$this->test_container->replace_with_concrete( ProductLoader::class, $mock_loader );
 
+		$mock_memory_manager = $this->createMock( MemoryManager::class );
+		$this->test_container->replace_with_concrete( MemoryManager::class, $mock_memory_manager );
+
 		$mock_feed = $this->createMock( FeedInterface::class );
 
 		// Setup everything that comes from the integration, and the integration itself.
@@ -116,20 +108,6 @@ class ProductWalkerTest extends ProductFeedTestCase {
 		$mock_integration = $this->createMock( IntegrationInterface::class );
 		$mock_integration->expects( $this->once() )->method( 'get_product_mapper' )->willReturn( $mock_mapper );
 		$mock_integration->expects( $this->once() )->method( 'get_feed_validator' )->willReturn( $mock_validator );
-
-		if ( $add_args_filter ) {
-			// Add a filter that unsets the category query arg.
-			add_filter(
-				'wpfoai_product_feed_args',
-				function ( $args, $integration ) use ( $mock_integration ) {
-					$this->assertSame( $mock_integration, $integration );
-					unset( $args['category'] );
-					return $args;
-				},
-				10,
-				2
-			);
-		}
 
 		/**
 		 * Set up data & expectations.
@@ -219,6 +197,41 @@ class ProductWalkerTest extends ProductFeedTestCase {
 			$this->assertEquals( ++$processed_iterations, $progress->processed_batches );
 			$this->assertEquals( min( $processed_iterations * $batch_size, $number_of_products ), $progress->processed_items );
 		};
+
+		if ( $add_args_filter ) {
+			// Add a filter that unsets the category query arg.
+			add_filter(
+				'wpfoai_product_feed_args',
+				function ( $args, $integration ) use ( $mock_integration ) {
+					$this->assertSame( $mock_integration, $integration );
+					unset( $args['category'] );
+					return $args;
+				},
+				10,
+				2
+			);
+		}
+
+		// Memory management: Always start with 90%. Eatch batch takes up 20%.
+		$available_memory = 90;
+		$mock_memory_manager->expects( $this->exactly( $expected_iterations + 1 ) )
+			->method( 'get_available_memory' )
+			->willReturnCallback(
+				function () use ( &$available_memory ) {
+					$available_memory -= 20;
+					return $available_memory;
+				}
+			);
+		// Flushing cashes frees up memory up to 46% (just a bit over half).
+		// So once memory gets low, it remains just above the threshold (half of 90% or 45%).
+		$flushes = max( 0, $expected_iterations - 1 );
+		$mock_memory_manager->expects( $this->exactly( $flushes ) )
+			->method( 'flush_caches' )
+			->willReturnCallback(
+				function () use ( &$available_memory ) {
+					$available_memory = 46;
+				}
+			);
 
 		/**
 		 * Finally, get the walker and go!

--- a/tests/unit/ProductFeed/Feed/ProductWalkerTest.php
+++ b/tests/unit/ProductFeed/Feed/ProductWalkerTest.php
@@ -1,0 +1,234 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\ProductFeedForOpenAI\Feed;
+
+use WC_Helper_Product;
+use WC_Product;
+use Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\IntegrationInterface;
+use Automattic\WooCommerce\ProductFeedForOpenAI\ProductFeedTestCase;
+
+/**
+ * ProductWalkerTest class.
+ */
+class ProductWalkerTest extends ProductFeedTestCase {
+	public function tearDown(): void {
+		parent::tearDown();
+		remove_all_filters( 'wpfoai_product_feed_args' );
+	}
+
+	public function test_from_integration() {
+		$mock_integration = $this->createMock( IntegrationInterface::class );
+		$mock_feed        = $this->createMock( FeedInterface::class );
+
+		$mock_integration->expects( $this->once() )
+			->method( 'get_product_feed_query_args' )
+			->willReturn( [] );
+		$mock_integration->expects( $this->once() )
+			->method( 'get_product_mapper' )
+			->willReturn( $this->createMock( ProductMapperInterface::class ) );
+		$mock_integration->expects( $this->once() )
+			->method( 'get_feed_validator' )
+			->willReturn( $this->createMock( FeedValidatorInterface::class ) );
+
+		ProductWalker::from_integration( $mock_integration, $mock_feed );
+	}
+
+	public function provider_optimal_path(): array {
+		return [
+			'No Results'                        => [
+				'number_of_products' => 0,
+				'batch_size'         => 10,
+				'add_args_filter'    => true,
+			],
+			'Single batch'                      => [
+				'number_of_products' => 10,
+				'batch_size'         => 100,
+				'add_args_filter'    => false,
+			],
+			'Multiple batches, half last batch' => [
+				'number_of_products' => 5 * 12 - 6,
+				'batch_size'         => 12,
+				'add_args_filter'    => true,
+			],
+			'Multiple batches, full last batch' => [
+				'number_of_products' => 5 * 13,
+				'batch_size'         => 13,
+				'add_args_filter'    => false,
+			],
+		];
+	}
+
+	/**
+	 * Test the optimal path for the product walker with varying results..
+	 *
+	 * @param int  $number_of_products The number of products to generate.
+	 * @param int  $batch_size         The batch size to use.
+	 * @param bool $add_args_filter    Whether the args filter is present.
+	 *
+	 * @dataProvider provider_optimal_path
+	 */
+	public function test_optimal_path( int $number_of_products, int $batch_size, bool $add_args_filter ) {
+		/**
+		 * Prepare all mocked data.
+		 */
+
+		// There should be at least one iteration, even with zero products.
+		$expected_iterations = max( 1, (int) ceil( $number_of_products / $batch_size ) );
+
+		// Generate products, group them into resulting batches.
+		$loader_results     = [];
+		$generated_products = 0;
+		for ( $i = 0; $i < $expected_iterations; $i++ ) {
+			$page = [];
+			for ( $j = 1; $j <= $batch_size && $generated_products++ < $number_of_products; $j++ ) {
+				$page[] = WC_Helper_Product::create_simple_product();
+			}
+
+			$loader_results[] = (object) [
+				'products'      => $page,
+				'total'         => $number_of_products,
+				'max_num_pages' => $expected_iterations,
+			];
+		}
+
+		// Additional parameters for the query.
+		$parent_exclude        = -156;
+		$additional_query_args = [
+			'parent_exclude' => $parent_exclude,
+			'category'       => [ 'shirts' ],
+		];
+
+		// The 11th product will always be rejected due to a validation error.
+		$validation_compensation = ( $number_of_products > 10 ? 1 : 0 );
+
+		/**
+		 * Set up all dependencies, including mocks.
+		 */
+		$mock_loader = $this->createMock( ProductLoader::class );
+		$this->test_container->replace_with_concrete( ProductLoader::class, $mock_loader );
+
+		$mock_feed = $this->createMock( FeedInterface::class );
+
+		// Setup everything that comes from the integration, and the integration itself.
+		$mock_mapper      = $this->createMock( ProductMapperInterface::class );
+		$mock_validator   = $this->createMock( FeedValidatorInterface::class );
+		$mock_integration = $this->createMock( IntegrationInterface::class );
+		$mock_integration->expects( $this->once() )->method( 'get_product_mapper' )->willReturn( $mock_mapper );
+		$mock_integration->expects( $this->once() )->method( 'get_feed_validator' )->willReturn( $mock_validator );
+
+		if ( $add_args_filter ) {
+			// Add a filter that unsets the category query arg.
+			add_filter(
+				'wpfoai_product_feed_args',
+				function ( $args, $integration ) use ( $mock_integration ) {
+					$this->assertSame( $mock_integration, $integration );
+					unset( $args['category'] );
+					return $args;
+				},
+				10,
+				2
+			);
+		}
+
+		/**
+		 * Set up data & expectations.
+		 */
+		$mock_integration->expects( $this->once() )
+			->method( 'get_product_feed_query_args' )
+			->willReturn( $additional_query_args );
+
+		// Set up the expectationf or each batch.
+		$loaded_page = 0;
+		$mock_loader->expects( $this->exactly( $expected_iterations ) )
+			->method( 'get_products' )
+			->with(
+				$this->callback(
+					function ( $args ) use ( &$loaded_page, $batch_size, $add_args_filter, $parent_exclude ) {
+						// Check pagination.
+						$this->assertEquals( ++$loaded_page, $args['page'] );
+						$this->assertEquals( $batch_size, $args['limit'] );
+
+						// The argument coming from the factory method should be here.
+						$this->assertEquals( $parent_exclude, $args['parent_exclude'] );
+
+						// There would be a category, unless the filter removed it..
+						if ( $add_args_filter ) {
+							$this->assertArrayNotHasKey( 'category', $args );
+						} else {
+							$this->assertArrayHasKey( 'category', $args );
+							$this->assertEquals( [ 'shirts' ], $args['category'] );
+						}
+						return true;
+					}
+				)
+			)
+			->willReturnCallback(
+				function () use ( &$loader_results ) {
+					return array_shift( $loader_results );
+				}
+			);
+
+		// Set up the mapper.
+		$mock_mapper->expects( $this->exactly( $number_of_products ) )
+			->method( 'map_product' )
+			->with( $this->isInstanceOf( WC_Product::class ) )
+			->willReturnCallback(
+				function ( WC_Product $product ) {
+					return [
+						'id' => $product->get_id(),
+					];
+				}
+			);
+
+		// Set up the validator.
+		$validated_products = 0;
+		$mock_validator->expects( $this->exactly( $number_of_products ) )
+			->method( 'validate_entry' )
+			->with( $this->isType( 'array' ), $this->isInstanceOf( WC_Product::class ) )
+			->willReturnCallback(
+				function ( array $mapped_data, WC_Product $product ) use ( &$validated_products ) {
+					$this->assertEquals( $product->get_id(), $mapped_data['id'] );
+
+					// Pick a "random" product to invalidate.
+					$validated_products++;
+					if ( 11 === $validated_products ) {
+						return [ 'error' => 'Some validation error' ];
+					}
+					return [];
+				}
+			);
+
+		// Make sure that the field is initiated, added to, and ended.
+		$mock_feed->expects( $this->once() )->method( 'start' );
+		$mock_feed->expects( $this->once() )->method( 'end' );
+		$mock_feed->expects( $this->exactly( $number_of_products - $validation_compensation ) )
+			->method( 'add_entry' )
+			->with( $this->isType( 'array' ) );
+
+		// Make sure that progress is indicated correctly.
+		$processed_iterations = 0;
+		$walker_callback      = function ( WalkerProgress $progress ) use (
+			$number_of_products,
+			$expected_iterations,
+			&$processed_iterations,
+			$batch_size,
+		) {
+			$this->assertEquals( $number_of_products, $progress->total_count );
+			$this->assertEquals( $expected_iterations, $progress->total_batch_count );
+			$this->assertEquals( ++$processed_iterations, $progress->processed_batches );
+			$this->assertEquals( min( $processed_iterations * $batch_size, $number_of_products ), $progress->processed_items );
+		};
+
+		/**
+		 * Finally, get the walker and go!
+		 */
+		$walker = ProductWalker::from_integration(
+			$mock_integration,
+			$mock_feed
+		);
+
+		$walker->set_batch_size( $batch_size );
+		$walker->walk( $walker_callback );
+	}
+}

--- a/tests/unit/ProductFeed/Integrations/OpenAi/SettingsTest.php
+++ b/tests/unit/ProductFeed/Integrations/OpenAi/SettingsTest.php
@@ -1,0 +1,193 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\OpenAi;
+
+use Automattic\WooCommerce\ProductFeedForOpenAI\ProductFeedTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use WC_Helper_Product;
+use WP_CLI\Context\Admin;
+
+/**
+ * Settings test class.
+ */
+class SettingsTest extends ProductFeedTestCase {
+	/**
+	 * System under test.
+	 *
+	 * @var Settings
+	 */
+	private Settings $sut;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut = new Settings();
+	}
+
+	public function test_get_returns_privacy_url() {
+		// Fall back to the default option if there is no privacy policy page set.
+		$this->assertEquals(
+			'https://example.com/',
+			$this->sut->get( 'privacy_url', 'https://example.com/' )
+		);
+
+		// When there is a privacy policy page set, it should return the permalink.
+		// Use a random product, it will have a link too.
+		$product = WC_Helper_Product::create_simple_product();
+		update_option( 'wp_page_for_privacy_policy', $product->get_id() );
+		$this->assertEquals(
+			$product->get_permalink(),
+			$this->sut->get( 'privacy_url', 'https://example.com/' )
+		);
+	}
+
+	public function test_get_returns_tos_and_returns_url() {
+		// Fall back to the default option if there is no T&C policy page set.
+		$this->assertEquals(
+			'https://example.com/',
+			$this->sut->get( 'tos_url', 'https://example.com/' )
+		);
+		$this->assertEquals(
+			'https://example.com/',
+			$this->sut->get( 'returns_url', 'https://example.com/' )
+		);
+
+		// When there is a T&C policy page set, it should return the permalink.
+		// Use a random product, it will have a link too.
+		$product = WC_Helper_Product::create_simple_product();
+		update_option( 'woocommerce_terms_page_id', $product->get_id() );
+		$this->assertEquals(
+			$product->get_permalink(),
+			$this->sut->get( 'tos_url', 'https://example.com/' )
+		);
+		$this->assertEquals(
+			$product->get_permalink(),
+			$this->sut->get( 'returns_url', 'https://example.com/' )
+		);
+	}
+
+	public function test_get_seller_name_returns_blog_name() {
+		$this->assertEquals(
+			get_bloginfo( 'name' ),
+			$this->sut->get( 'seller_name', 'https://example.com/' )
+		);
+	}
+
+	public function test_get_returns_random_openai_setting() {
+		update_option(
+			'woocommerce_agentic_agent_registry',
+			[
+				'openai'  => [
+					'basic_setting' => 'xyz',
+				],
+				'general' => [
+					'basic_setting'   => 'xyz',
+					'another_setting' => 'abc',
+				],
+			]
+		);
+
+		$this->assertEquals(
+			'xyz',
+			$this->sut->get( 'basic_setting' )
+		);
+		$this->assertEquals(
+			'abc',
+			$this->sut->get( 'another_setting' )
+		);
+	}
+
+	public function test_get_endpoint_url_returns_feed_url() {
+		update_option(
+			'woocommerce_agentic_agent_registry',
+			[
+				'openai' => [
+					'feed_url' => 'https://example.com/',
+				],
+			]
+		);
+
+		$this->assertEquals(
+			'https://example.com/',
+			$this->sut->get_endpoint_url()
+		);
+	}
+
+	public function test_get_endpoint_url_returns_null_if_no_feed_url_is_set() {
+		update_option(
+			'woocommerce_agentic_agent_registry',
+			[
+				'openai' => [],
+			]
+		);
+
+		$this->assertNull( $this->sut->get_endpoint_url() );
+	}
+
+	public function test_get_endpoint_url_respects_filter() {
+		update_option(
+			'woocommerce_agentic_agent_registry',
+			[
+				'openai' => [
+					'feed_url' => 'https://example.com/',
+				],
+			]
+		);
+		add_filter( 'wpfoai_openai_endpoint_url', fn() => 'https://example.com/filtered/' );
+		$this->assertEquals(
+			'https://example.com/filtered/',
+			$this->sut->get_endpoint_url()
+		);
+	}
+
+	public function test_extend_providers() {
+		$providers = [
+			[
+				'id'     => 'openai',
+				'fields' => [
+					[
+						'title' => 'Test Field',
+						'id'    => 'test_field',
+					],
+				],
+			],
+		];
+
+		$updated_providers = $this->sut->extend_providers( $providers, [] );
+		$this->assertIsArray( $updated_providers );
+		$this->assertContains(
+			'test_field',
+			wp_list_pluck( $providers[0]['fields'], 'id' ),
+			'Previously existing field remains'
+		);
+		$this->assertNotCount(
+			1,
+			$updated_providers[0]['fields'],
+			'New fields are added'
+		);
+	}
+
+	public function test_save_settings() {
+		$registry = [
+			'openai' => [
+				'feed_url'      => 'https://example.com/',
+				'return_window' => 30,
+			],
+		];
+
+// 		$user_id = self::factory()->user->create( ['role' => 'administrator'] );
+// wp_set_current_user( $user_id );
+
+		$_SERVER['HTTP_REFERER'] = admin_url( '/' );
+		$_POST['_wpnonce'] = wp_create_nonce( 'woocommerce-settings' );
+
+		$_POST['woocommerce_agentic_openai_feed_url']      = 'https://example.com/updated/';
+		$_POST['woocommerce_agentic_openai_return_window'] = '60';
+
+		$updated_registry = $this->sut->save_settings( $registry );
+
+		$this->assertEquals( 'https://example.com/updated/', $updated_registry['openai']['feed_url'] );
+		$this->assertEquals( 60, $updated_registry['openai']['return_window'] );
+	}
+}

--- a/tests/unit/ProductFeed/Integrations/OpenAi/SettingsTest.php
+++ b/tests/unit/ProductFeed/Integrations/OpenAi/SettingsTest.php
@@ -1,12 +1,10 @@
 <?php
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\OpenAi;
 
 use Automattic\WooCommerce\ProductFeedForOpenAI\ProductFeedTestCase;
-use PHPUnit\Framework\MockObject\MockObject;
 use WC_Helper_Product;
-use WP_CLI\Context\Admin;
 
 /**
  * Settings test class.
@@ -175,12 +173,6 @@ class SettingsTest extends ProductFeedTestCase {
 				'return_window' => 30,
 			],
 		];
-
-// 		$user_id = self::factory()->user->create( ['role' => 'administrator'] );
-// wp_set_current_user( $user_id );
-
-		$_SERVER['HTTP_REFERER'] = admin_url( '/' );
-		$_POST['_wpnonce'] = wp_create_nonce( 'woocommerce-settings' );
 
 		$_POST['woocommerce_agentic_openai_feed_url']      = 'https://example.com/updated/';
 		$_POST['woocommerce_agentic_openai_return_window'] = '60';

--- a/tests/unit/ProductFeed/ProductFeedTestCase.php
+++ b/tests/unit/ProductFeed/ProductFeedTestCase.php
@@ -57,7 +57,7 @@ class ProductFeedTestCase extends WC_Unit_Test_Case {
 	 * @return TestContainer The replacement container.
 	 */
 	private function get_replacement_container( ?TestContainer $current_container = null ): TestContainer {
-		// The same instance will be shared accross all tests.
+		// The same instance will be shared across all tests.
 		static $test_container;
 
 		// Just return the test container if it already set.

--- a/tests/unit/ProductFeed/ProductFeedTestCase.php
+++ b/tests/unit/ProductFeed/ProductFeedTestCase.php
@@ -4,12 +4,36 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\ProductFeedForOpenAI;
 
 use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionClass;
+use ReflectionProperty;
 use WC_Unit_Test_Case;
 
 /**
  * ProductFeed test case class.
  */
 class ProductFeedTestCase extends WC_Unit_Test_Case {
+	/**
+	 * Extended version of RuntimeContainer, used during tests.
+	 *
+	 * @var TestContainer
+	 */
+	protected TestContainer $test_container;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// Initialize the test container if needed.
+		$this->test_container = $this->get_replacement_container(
+			isset( $this->test_container ) ? $this->test_container : null
+		);
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		$this->test_container->reset_all_replacements();
+	}
+
 	/**
 	 * Creates a mock object.
 	 *
@@ -24,5 +48,56 @@ class ProductFeedTestCase extends WC_Unit_Test_Case {
 	// phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found,Squiz.Commenting.FunctionComment.IncorrectTypeHint
 	public function createMock( string $original_class_name ): MockObject {
 		return parent::createMock( $original_class_name );
+	}
+
+	/**
+	 * Get the replacement container.
+	 *
+	 * @param TestContainer|null $current_container The current test container.
+	 * @return TestContainer The replacement container.
+	 */
+	private function get_replacement_container( ?TestContainer $current_container = null ): TestContainer {
+		// The same instance will be shared accross all tests.
+		static $test_container;
+
+		// Just return the test container if it already set.
+		if ( isset( $test_container ) && $test_container === $current_container ) {
+			return $current_container;
+		}
+
+		$plugin_instance = wpfoai_plugin();
+		$plugin_property = $this->make_property_accessible( $plugin_instance, 'container' );
+		$main_container  = $plugin_property->getValue( $plugin_instance );
+
+		// If the test container is already used in the plugin, don't change anything.
+		if ( $main_container === $test_container ) {
+			return $test_container;
+		}
+
+		// Fetch the `initial_resolved_cache` from the existing `RuntimeContainer`.
+		$container_property = $this->make_property_accessible( $main_container, 'container' );
+		$runtime_container  = $container_property->getValue( $main_container );
+		$cache_property     = $this->make_property_accessible( $runtime_container, 'initial_resolved_cache' );
+		$original_cache     = $cache_property->getValue( $runtime_container );
+
+		// Create a test container with the same initial cache.
+		$test_container = new TestContainer( $original_cache );
+		$plugin_property->setValue( $plugin_instance, $test_container );
+
+		return $test_container;
+	}
+
+	/**
+	 * Makes a property accessible and returns it.
+	 *
+	 * @param object $obj           The object to make the property accessible.
+	 * @param string $property_name The name of the property to make accessible.
+	 * @return ReflectionProperty The property.
+	 */
+	private function make_property_accessible( object $obj, string $property_name ): ReflectionProperty {
+		$reflection = new ReflectionClass( $obj );
+		$property   = $reflection->getProperty( $property_name );
+		$property->setAccessible( true );
+		return $property;
 	}
 }

--- a/tests/unit/ProductFeed/ProductFeedTestCase.php
+++ b/tests/unit/ProductFeed/ProductFeedTestCase.php
@@ -1,0 +1,28 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\ProductFeedForOpenAI;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use WC_Unit_Test_Case;
+
+/**
+ * ProductFeed test case class.
+ */
+class ProductFeedTestCase extends WC_Unit_Test_Case {
+	/**
+	 * Creates a mock object.
+	 *
+	 * This method does not work differently from `createMock`,
+	 * but the DocBlock comment indicates a proper return type,
+	 * combining `MockObject` and the provided class name.
+	 *
+	 * @template ID
+	 * @param class-string<ID> $original_class_name Name of the class to mock.
+	 * @return ID|MockObject
+	 */
+	// phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found,Squiz.Commenting.FunctionComment.IncorrectTypeHint
+	public function createMock( string $original_class_name ): MockObject {
+		return parent::createMock( $original_class_name );
+	}
+}

--- a/tests/unit/ProductFeed/ProductFeedTestCase.php
+++ b/tests/unit/ProductFeed/ProductFeedTestCase.php
@@ -60,7 +60,7 @@ class ProductFeedTestCase extends WC_Unit_Test_Case {
 		// The same instance will be shared across all tests.
 		static $test_container;
 
-		// Just return the test container if it already set.
+		// Just return the test container if it is already set.
 		if ( isset( $test_container ) && $test_container === $current_container ) {
 			return $current_container;
 		}

--- a/tests/unit/ProductFeed/Storage/JsonFileFeedTest.php
+++ b/tests/unit/ProductFeed/Storage/JsonFileFeedTest.php
@@ -23,7 +23,7 @@ class JsonFileFeedTest extends ProductFeedTestCase {
 	}
 
 	public function test_feed_file_is_created() {
-		// Use the current itme for the test as the time in the SUT to avoid flakiness.
+		// Use the current time for the test as the time in the SUT to avoid flakiness.
 		$current_time = time();
 		add_filter( 'wpfoai_feed_time', fn() => $current_time );
 

--- a/tests/unit/ProductFeed/Storage/JsonFileFeedTest.php
+++ b/tests/unit/ProductFeed/Storage/JsonFileFeedTest.php
@@ -1,0 +1,81 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\ProductFeedForOpenAI\Storage;
+
+use Automattic\WooCommerce\ProductFeedForOpenAI\ProductFeedTestCase;
+
+// This file works directly with local files. That's fine.
+// phpcs:disable WordPress.WP.AlternativeFunctions
+
+if ( ! function_exists( 'WP_Filesystem' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/file.php';
+}
+
+
+/**
+ * JsonFileFeedTest class.
+ */
+class JsonFileFeedTest extends ProductFeedTestCase {
+	public function test_feed_file_is_created() {
+		// Make sure there is no directory and that it will be created.
+		$directory = $this->get_and_delete_dir();
+
+		$feed = new JsonFileFeed( 'test-feed' );
+		$feed->start();
+		$feed->end();
+
+		$path = $feed->get_file_path();
+		$this->assertStringContainsString( 'product-feeds', $path );
+		$this->assertStringContainsString( $directory, $path );
+		$this->assertTrue( file_exists( $path ) );
+		$this->assertEquals( '[]', file_get_contents( $path ) );
+	}
+
+	public function test_feed_file_is_created_with_entries() {
+		$data = [
+			[
+				'name'  => 'First Entry',
+				'price' => 100,
+			],
+			[
+				'name'  => 'Second Entry',
+				'price' => 333,
+			],
+		];
+
+		$feed = new JsonFileFeed( 'test-feed' );
+		$feed->start();
+		foreach ( $data as $entry ) {
+			$feed->add_entry( $entry );
+		}
+		$feed->end();
+
+		$this->assertEquals(
+			wp_json_encode( $data ),
+			file_get_contents( $feed->get_file_path() )
+		);
+	}
+
+	public function test_get_file_url_returns_null_if_not_completed() {
+		$feed = new JsonFileFeed( 'test-feed' );
+		$feed->start();
+		$this->assertNull( $feed->get_file_url() );
+		$feed->end();
+	}
+
+	/**
+	 * Gets the directory for feed files, but also deletes it.
+	 *
+	 * @return string The directory path.
+	 */
+	private function get_and_delete_dir(): string {
+		$directory = wp_upload_dir()['basedir'] . '/product-feeds';
+		if ( is_dir( $directory ) ) {
+			global $wp_filesystem;
+			WP_Filesystem();
+			$wp_filesystem->rmdir( $directory, true );
+		}
+		return $directory;
+	}
+}

--- a/tests/unit/ProductFeed/Storage/JsonFileFeedTest.php
+++ b/tests/unit/ProductFeed/Storage/JsonFileFeedTest.php
@@ -17,7 +17,16 @@ if ( ! function_exists( 'WP_Filesystem' ) ) {
  * JsonFileFeedTest class.
  */
 class JsonFileFeedTest extends ProductFeedTestCase {
+	public function tearDown(): void {
+		parent::tearDown();
+		remove_all_filters( 'wpfoai_feed_time' );
+	}
+
 	public function test_feed_file_is_created() {
+		// Use the current itme for the test as the time in the SUT to avoid flakiness.
+		$current_time = time();
+		add_filter( 'wpfoai_feed_time', fn() => $current_time );
+
 		// Make sure there is no directory and that it will be created.
 		$directory = $this->get_and_delete_dir();
 
@@ -28,6 +37,8 @@ class JsonFileFeedTest extends ProductFeedTestCase {
 		$path = $feed->get_file_path();
 		$this->assertStringContainsString( 'product-feeds', $path );
 		$this->assertStringContainsString( $directory, $path );
+		$this->assertStringContainsString( gmdate( 'Y-m-d', $current_time ), $path );
+		$this->assertStringContainsString( wp_hash( 'test-feed' . gmdate( 'r', $current_time ) ), $path );
 		$this->assertTrue( file_exists( $path ) );
 		$this->assertEquals( '[]', file_get_contents( $path ) );
 

--- a/tests/unit/ProductFeed/Storage/JsonFileFeedTest.php
+++ b/tests/unit/ProductFeed/Storage/JsonFileFeedTest.php
@@ -30,6 +30,11 @@ class JsonFileFeedTest extends ProductFeedTestCase {
 		$this->assertStringContainsString( $directory, $path );
 		$this->assertTrue( file_exists( $path ) );
 		$this->assertEquals( '[]', file_get_contents( $path ) );
+
+		$url = $feed->get_file_url();
+		$this->assertNotNull( $url );
+		$this->assertStringEndsWith( '.json', (string) $url );
+		$this->assertStringContainsString( '/product-feeds/', (string) $url );
 	}
 
 	public function test_feed_file_is_created_with_entries() {
@@ -62,6 +67,46 @@ class JsonFileFeedTest extends ProductFeedTestCase {
 		$feed->start();
 		$this->assertNull( $feed->get_file_url() );
 		$feed->end();
+	}
+
+	public function test_get_file_path_before_start_throws_type_error() {
+		$feed = new JsonFileFeed( 'test-feed' );
+		$this->expectException( \TypeError::class );
+		// Property is unset until start(); return type is string → TypeError.
+		$feed->get_file_path();
+	}
+
+	public function test_add_entry_before_start_throws_type_error() {
+		$feed = new JsonFileFeed( 'test-feed' );
+		$this->expectException( \TypeError::class );
+		$feed->add_entry( [ 'name' => 'oops' ] );
+	}
+
+	public function test_end_before_start_throws_type_error() {
+		$feed = new JsonFileFeed( 'test-feed' );
+		$this->expectException( \TypeError::class );
+		$feed->end();
+	}
+
+	public function test_start_throws_when_directory_cannot_be_created() {
+		// Ensure clean state then create a FILE where the directory should be.
+		$this->get_and_delete_dir();
+		$uploads_dir = wp_upload_dir()['basedir'];
+		$block_path  = $uploads_dir . '/product-feeds';
+
+		// Create a file to block directory creation.
+		file_put_contents( $block_path, 'blocking file' );
+
+		try {
+			$feed = new JsonFileFeed( 'test-feed' );
+			$this->expectException( \Exception::class );
+			$feed->start();
+		} finally {
+			// Cleanup: remove blocking file.
+			if ( file_exists( $block_path ) && is_file( $block_path ) ) {
+				unlink( $block_path );
+			}
+		}
 	}
 
 	/**

--- a/tests/unit/ProductFeed/TestContainer.php
+++ b/tests/unit/ProductFeed/TestContainer.php
@@ -1,0 +1,29 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\ProductFeedForOpenAI;
+
+use Automattic\WooCommerce\ProductFeedForOpenAI\Core\DependencyManagement\RuntimeContainer;
+
+/**
+ * Dependency injection container used during unit tests.
+ */
+class TestContainer extends RuntimeContainer {
+	/**
+	 * Replace a class/interface with a concrete (mock) implementation.
+	 *
+	 * @param string $class_name The class/interface name to replace.
+	 * @param object $concrete The concrete (mock) implementation.
+	 */
+	public function replace_with_concrete( string $class_name, object $concrete ): void {
+		$this->resolved_cache[ $class_name ] = $concrete;
+	}
+
+	/**
+	 * Reset the resolved cache, together with all replacements.
+	 */
+	public function reset_all_replacements(): void {
+		$this->resolved_cache = $this->initial_resolved_cache;
+	}
+}

--- a/tests/unit/ProductFeed/Utils/TestUtilsTest.php
+++ b/tests/unit/ProductFeed/Utils/TestUtilsTest.php
@@ -1,0 +1,54 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\ProductFeedForOpenAI\Utils;
+
+use Automattic\WooCommerce\ProductFeedForOpenAI\Core\DependencyManagement\ContainerException;
+use Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\IntegrationInterface;
+use Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\OpenAi\OpenAiIntegration;
+use Automattic\WooCommerce\ProductFeedForOpenAI\ProductFeedTestCase;
+
+/**
+ * Test class for unit test utilities.
+ */
+class TestUtilsTest extends ProductFeedTestCase {
+	public function test_container_replacement() {
+		// Prepare a new class that will be used as a replacement.
+		$replacement_helper = ( new class() extends StringHelper {
+			public function dynamic_bool_string( $value ): string {
+				return StringHelper::bool_string( $value );
+			}
+		} );
+
+		// Load a normal class from the container.
+		$string_helper = $this->test_container->get( StringHelper::class );
+		$this->assertInstanceOf( StringHelper::class, $string_helper );
+
+		// Replace a class in the container with a specific instance.
+		$this->test_container->replace_with_concrete( StringHelper::class, $replacement_helper );
+		$replaced = wpfoai_get_service( StringHelper::class );
+		$this->assertEquals( $replacement_helper, $replaced );
+
+		// Set the particular implementation of an interface.
+		$integration = wpfoai_get_service( OpenAiIntegration::class );
+		$this->test_container->replace_with_concrete( IntegrationInterface::class, $integration );
+		$interface_instance = wpfoai_get_service( IntegrationInterface::class );
+		$this->assertInstanceOf( OpenAiIntegration::class, $interface_instance );
+
+		// For unit tests, test replacement with a mock.
+		$mock_integration = $this->createMock( IntegrationInterface::class );
+		$mock_integration->expects( $this->once() )
+			->method( 'get_id' )
+			->willReturn( 'openai' );
+		$this->test_container->replace_with_concrete( IntegrationInterface::class, $mock_integration );
+		$this->assertSame( $mock_integration, wpfoai_get_service( IntegrationInterface::class ) );
+		$this->assertEquals( 'openai', wpfoai_get_service( IntegrationInterface::class )->get_id() );
+
+		// Reset all replacements.
+		$this->test_container->reset_all_replacements();
+
+		// Expect an exception, as the interface does not have a specified implementation.
+		$this->expectException( ContainerException::class );
+		$integration = wpfoai_get_service( IntegrationInterface::class );
+	}
+}

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -3,6 +3,9 @@
 ini_set( 'display_errors', '1' );
 error_reporting( E_ALL );
 
+// Define a constnat to use in tests.
+define( 'PRODUCT_FEED_UNIT_TESTS', true );
+
 // Let wp-phpunit tell us where the WP test suite lives.
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 if ( ! $_tests_dir ) {

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -104,3 +104,6 @@ function initialize_dependency_injection() {
 	$GLOBALS['wc_container'] = $inner_container;
 }
 initialize_dependency_injection();
+
+// Include ProductFeed core test files.
+require_once __DIR__ . '/ProductFeed/ProductFeedTestCase.php';

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -107,3 +107,4 @@ initialize_dependency_injection();
 
 // Include ProductFeed core test files.
 require_once __DIR__ . '/ProductFeed/ProductFeedTestCase.php';
+require_once __DIR__ . '/ProductFeed/TestContainer.php';


### PR DESCRIPTION
## Description

This PR centralizes `ProductWalker` initialization, delegates query argument preparation to integrations, and allows the `AsyncGenerator` to work with custom parameters, treating each set of integration + parameters as an individual entity.

The changes are being implemented for multiple reasons:

1. **Integrations can change how products are queried**. An early example is the fact that variations appear as stand-alone, purchasable products in the OpenAI feed, while the POS feed requires the parent product in the feed as well.
2. **Feeds might not always be the same**. While OpenAI has a strict feed schema, our mobile apps might require data to change with time. Basing generation on individual parameters (e.g., expected product fields) allows multiple entities to consume data differently while keeping the generation process streamlined.
3. This is a stepping stone towards **`AsyncGenerator`'s abstraction** to work with multiple integrations.

### Walker initialization

Rather than instantiating the Walker directly in multiple places, that is now done through a centralized static factory method of the Walker. The thinking behind the method is as follows:

- Requires an integration and loads the product mapper and validator directly from the integraiton.
- Preserves the feed (`FeedInterface`) as an external parameter. Even though all feeds are `JsonFileFeed` currently, that might easily change based not only on the provider but also on context (CLI vs REST, etc.)
- Combines some default product query arguments with the arguments for the given integration. This allows the `wpfoai_product_feed_args` filter to include the integration as an argument for integration-specific hooks.

### Allow individual arguments in the async generator

The generator moves away from the single option that was previously used to a dynamic option key, based on the integration and additional external parameters.

External parameters can be provided by other actors like the POS `ApiController`. At this stage, they are always an empty array:

https://github.com/woocommerce/OpenAI-Product-Feed/blob/f20480dd1066cf057079f6ee7c9737250d885bcf/src/Integrations/POSCatalog/ApiController.php#L82-L85

After some discussions in p1761032826289079-slack-C09EWAXSYD9 tomorrow, this will likely change. But even if it does not, the functionality will be available for when needed.

## Tests

I've added tests for most files that were not covered with tests. Below are the exceptions. There are quite a few of them, but they seem... reasonable. Please don't hesitate to disagree with me.

| File/Class(es) | Reason |
|-|-|
| `Plugin` | The file simply initializes the necessary classes.
| `CLI\Command` | Testing CLI is complicated and requires [an elaborate setup](https://github.com/wp-cli/wp-cli-tests). Since the command only gathers parameters and runs relatively high-level methods, there isn't much actual functionality to test anyway. |
| `DeliveryMethods\PushFile` | I've actually covered the class, but only `check_setup()` and some failures. I can't properly test curl in unit tests | 
| `Utils\MemoryManager` | Most of the functionality there is borrowed from WPCOM | 
| `Integrations\POSCatalog\*` | All of it is just a preview and can be handled separately once we've got an agreed-upon implementation. |
| `Integrations\OpenAi\DevHelpers` | Those are only local helpers, and the class is mostly HTML and CSS. |
| `Integrations\OpenAi\ProductFieldsController` | Same as above |
| `Integrations\OpenAi\FeedSchema` | This is a giant array! There is a bit of logic in `is_field_required`, but it is tested through the `FeedValidator`. |
| `Integrations\OpenAi\OpenAiIntegration` | This is just a coordinator; there is no logic to test. |
| `Integrations\OpenAi\Settings` | ⏳ **In progress**. This row will be removed once done. |

# Testing instructions

This PR is focusing on abstraction/refactoring, bringing nearly no functional changes. The easiest way that covers the most ground would be to generate both an OpenAI feed through CLI and a POS one through the REST API:

```sh
# Generate the OpenAI, returning only the file path.
wp product-feed generate --integration=openai --silent

# Enter your credentials here
wp_auth="admin:4EkD qmKL EfTN LV6D Yf0E faj8"

# Repeat until the file URL appears
curl -u "${wp_auth}" -X POST http://host/wp-json/wc/product-catalog/v1/create\?XDEBUG_SESSION\=XDEBUG_ECLIPSE
```

The first step is to make sure that both files get generated. Once they are generated, compare both. The POS catalog should contain more entries, as it includes variable products.

Once the REST controller's parameters are defined and implemented, their outcome should be tested as well.

## Checklist

<!-- Mark completed items with an "x" -->

- [x] `npm run test:php` does not return errors.
- [x] `npm run lint:php` does not return errors.
- [x] Covered with additional unit tests.
- [x] Individualize file names based on context.
- [x] Add tests for `Settings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrations can supply configurable product-feed query arguments.
  * Per-request feed status keys for safer async feed generation.

* **Bug Fixes**
  * Removed sensitive fields from API responses.
  * More robust settings URL retrieval with safer fallbacks.

* **Refactor**
  * Memory-aware feed processing with improved batch handling and cache flushing.
  * Feed construction moved to a factory-style flow.
  * Deterministic, time-based feed file naming; longer feed expiry.

* **Tests**
  * Added comprehensive unit tests for feed processing, storage, walker, settings, and DI helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->