### PR TITLE
OpenAI Feed: use separator > for nested product_category

### DIFF
--- a/src/Integrations/OpenAi/ProductMapper.php
+++ b/src/Integrations/OpenAi/ProductMapper.php
@@ -334,7 +334,8 @@ final class ProductMapper implements ProductMapperInterface {
 	 * When a product has multiple categories, selects the one with the most levels.
 	 * Example: "Apparel & Accessories > Shoes > Running Shoes"
 	 *
-	 * @param \WC_Product $product Product object.
+	 * @param \WC_Product      $product Product object.
+	 * @param \WC_Product|null $parent_product Parent product for variations.
 	 * @return string|null Product category path or null.
 	 */
 	protected function get_product_category( \WC_Product $product, ?\WC_Product $parent_product ): ?string {

--- a/src/Integrations/OpenAi/ProductMapper.php
+++ b/src/Integrations/OpenAi/ProductMapper.php
@@ -339,8 +339,9 @@ final class ProductMapper implements ProductMapperInterface {
 	 */
 	protected function get_product_category( \WC_Product $product ): ?string {
 		// Find the deepest category by counting ancestors.
-		$category_deepest_id = null;
-		$max_depth           = -1;
+		$category_deepest_id  = null;
+		$ancestor_deepest_ids = [];
+		$max_depth            = -1;
 
 		foreach ( $product->get_category_ids() as $category_id ) {
 			$ancestor_ids = get_ancestors( $category_id, 'product_cat', 'taxonomy' );

--- a/src/Integrations/OpenAi/ProductMapper.php
+++ b/src/Integrations/OpenAi/ProductMapper.php
@@ -218,7 +218,7 @@ final class ProductMapper implements ProductMapperInterface {
 	 */
 	protected function get_enable_search( \WC_Product $product, ?\WC_Product $parent_product ): string {
 		// For variations, check parent product meta; for simple products, check product meta.
-		$check_product = $parent_product ? $parent_product : $product;
+		$check_product = $parent_product ?? $product;
 		$value         = $this->get_enable_with_override( $check_product, ProductFieldsController::KEY_DISABLE_SEARCH, 'enable_products_default', 'true' );
 		return StringHelper::bool_string( $value );
 	}
@@ -337,13 +337,17 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @param \WC_Product $product Product object.
 	 * @return string|null Product category path or null.
 	 */
-	protected function get_product_category( \WC_Product $product ): ?string {
-		// Find the deepest category by counting ancestors.
+	protected function get_product_category( \WC_Product $product, ?\WC_Product $parent_product ): ?string {
+		$check_product = $parent_product ?? $product;
+
+		/**
+		 * Step 1: Find the deepest category by counting ancestors.
+		 */
 		$category_deepest_id  = null;
 		$ancestor_deepest_ids = [];
 		$max_depth            = -1;
 
-		foreach ( $product->get_category_ids() as $category_id ) {
+		foreach ( $check_product->get_category_ids() as $category_id ) {
 			$ancestor_ids = get_ancestors( $category_id, 'product_cat', 'taxonomy' );
 			$depth        = count( $ancestor_ids );
 
@@ -354,20 +358,45 @@ final class ProductMapper implements ProductMapperInterface {
 			}
 		}
 
-		$ids_to_build   = array_reverse( $ancestor_deepest_ids );
-		$ids_to_build[] = $category_deepest_id;
+		if ( null === $category_deepest_id ) {
+			return null;
+		}
 
+		/**
+		 * Step 2: Build up the ID list with correct hierarchical order.
+		 */
+		$ordered_ids   = array_reverse( $ancestor_deepest_ids );
+		$ordered_ids[] = $category_deepest_id;
+
+		/**
+		 * Get category names.
+		 *
+		 * @param array<int, string> $category_names Arrays with key is category_id, value is category name.
+		 */
 		$category_names = get_terms(
 			[
-				'include'  => $ids_to_build,
+				'include'  => $ordered_ids,
 				'fields'   => 'id=>name',
 				'taxonomy' => 'product_cat',
 			]
 		);
 
-		return empty( $category_names )
-			? null
-			: implode( ' > ', $category_names );
+		if ( empty( $category_names ) || is_wp_error( $category_names ) ) {
+			return null;
+		}
+
+		/**
+		 * Step 3: Build the path in the correct hierarchical order. Because there is
+		 * no guarantee that category_names above have been in the correct order.
+		 */
+		$ordered_names = [];
+		foreach ( $ordered_ids as $term_id ) {
+			if ( isset( $category_names[ $term_id ] ) ) {
+				$ordered_names[] = $category_names[ $term_id ];
+			}
+		}
+
+		return empty( $ordered_names ) ? null : implode( ' > ', $ordered_names );
 	}
 
 	/**

--- a/src/Integrations/OpenAi/ProductMapper.php
+++ b/src/Integrations/OpenAi/ProductMapper.php
@@ -330,21 +330,43 @@ final class ProductMapper implements ProductMapperInterface {
 	/**
 	 * Get product category path.
 	 *
+	 * Returns the deepest (most specific) category path with hierarchical structure using " > " separator.
+	 * When a product has multiple categories, selects the one with the most levels.
+	 * Example: "Apparel & Accessories > Shoes > Running Shoes"
+	 *
 	 * @param \WC_Product $product Product object.
 	 * @return string|null Product category path or null.
 	 */
 	protected function get_product_category( \WC_Product $product ): ?string {
-		$terms = get_the_terms( $product->get_id(), 'product_cat' );
-		if ( ! $terms || is_wp_error( $terms ) ) {
-			return null;
+		// Find the deepest category by counting ancestors.
+		$category_deepest_id = null;
+		$max_depth           = -1;
+
+		foreach ( $product->get_category_ids() as $category_id ) {
+			$ancestor_ids = get_ancestors( $category_id, 'product_cat', 'taxonomy' );
+			$depth        = count( $ancestor_ids );
+
+			if ( $depth > $max_depth ) {
+				$max_depth            = $depth;
+				$category_deepest_id  = $category_id;
+				$ancestor_deepest_ids = $ancestor_ids;
+			}
 		}
 
-		$names = [];
-		foreach ( $terms as $term ) {
-			$names[] = $term->name;
-		}
+		$ids_to_build   = array_reverse( $ancestor_deepest_ids );
+		$ids_to_build[] = $category_deepest_id;
 
-		return empty( $names ) ? null : implode( ', ', $names );
+		$category_names = get_terms(
+			[
+				'include'  => $ids_to_build,
+				'fields'   => 'id=>name',
+				'taxonomy' => 'product_cat',
+			]
+		);
+
+		return empty( $category_names )
+			? null
+			: implode( ' > ', $category_names );
 	}
 
 	/**

--- a/src/Integrations/OpenAi/ProductMapper.php
+++ b/src/Integrations/OpenAi/ProductMapper.php
@@ -370,30 +370,13 @@ final class ProductMapper implements ProductMapperInterface {
 		$ordered_ids[] = $category_deepest_id;
 
 		/**
-		 * Get category names.
-		 *
-		 * @param array<int, string> $category_names Arrays with key is category_id, value is category name.
-		 */
-		$category_names = get_terms(
-			[
-				'include'  => $ordered_ids,
-				'fields'   => 'id=>name',
-				'taxonomy' => 'product_cat',
-			]
-		);
-
-		if ( empty( $category_names ) || is_wp_error( $category_names ) ) {
-			return null;
-		}
-
-		/**
-		 * Step 3: Build the path in the correct hierarchical order. Because there is
-		 * no guarantee that category_names above have been in the correct order.
+		 * Step 3: Get all ordered category names, and concatenate them.
 		 */
 		$ordered_names = [];
 		foreach ( $ordered_ids as $term_id ) {
-			if ( isset( $category_names[ $term_id ] ) ) {
-				$ordered_names[] = $category_names[ $term_id ];
+			$term = get_term( $term_id, 'product_cat' );
+			if ( $term && ! is_wp_error( $term ) ) {
+				$ordered_names[ $term_id ] = $term->name;
 			}
 		}
 

--- a/tests/unit/ProductFeed/Integrations/OpenAi/ProductMapperTest.php
+++ b/tests/unit/ProductFeed/Integrations/OpenAi/ProductMapperTest.php
@@ -299,6 +299,52 @@ class ProductMapperTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test enable_search for variation uses parent product meta
+	 */
+	public function test_map_product_enable_search_variation_uses_parent_meta(): void {
+		$variable_product = WC_Helper_Product::create_variation_product();
+		$variable_product->update_meta_data( ProductFieldsController::KEY_DISABLE_SEARCH, 'yes' );
+		$variable_product->save();
+
+		$variations = $variable_product->get_children();
+		$this->assertNotEmpty( $variations );
+
+		$variation = wc_get_product( $variations[0] );
+		$this->assertNotNull( $variation );
+
+		$result = $this->sut->map_product( $variation );
+
+		$this->assertArrayHasKey( 'enable_search', $result );
+		// Should use parent's disable setting.
+		$this->assertEquals( 'false', $result['enable_search'] );
+
+		$variable_product->delete( true );
+	}
+
+	/**
+	 * Test enable_checkout for variation uses parent product meta
+	 */
+	public function test_map_product_enable_checkout_variation_uses_parent_meta(): void {
+		$variable_product = WC_Helper_Product::create_variation_product();
+		$variable_product->update_meta_data( ProductFieldsController::KEY_DISABLE_CHECKOUT, 'yes' );
+		$variable_product->save();
+
+		$variations = $variable_product->get_children();
+		$this->assertNotEmpty( $variations );
+
+		$variation = wc_get_product( $variations[0] );
+		$this->assertNotNull( $variation );
+
+		$result = $this->sut->map_product( $variation );
+
+		$this->assertArrayHasKey( 'enable_checkout', $result );
+		// Should use parent's disable setting.
+		$this->assertEquals( 'false', $result['enable_checkout'] );
+
+		$variable_product->delete( true );
+	}
+
+	/**
 	 * Test price formatting with currency
 	 */
 	public function test_map_product_price_includes_currency(): void {
@@ -797,5 +843,203 @@ class ProductMapperTest extends \WC_Unit_Test_Case {
 		$this->assertArrayNotHasKey( 'sale_price_effective_date', $result );
 
 		$product->delete( true );
+	}
+
+	/**
+	 * Test product_category returns hierarchical path with separator
+	 */
+	public function test_map_product_category_hierarchical_path(): void {
+		// Create category hierarchy: Root > Child > Grandchild.
+		$root_cat = wp_insert_term( 'Root Category', 'product_cat' );
+		$this->assertIsArray( $root_cat );
+
+		$child_cat = wp_insert_term(
+			'Child Category',
+			'product_cat',
+			[ 'parent' => $root_cat['term_id'] ]
+		);
+		$this->assertIsArray( $child_cat );
+
+		$grandchild_cat = wp_insert_term(
+			'Grandchild Category',
+			'product_cat',
+			[ 'parent' => $child_cat['term_id'] ]
+		);
+		$this->assertIsArray( $grandchild_cat );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_category_ids( [ $grandchild_cat['term_id'] ] );
+		$product->save();
+
+		$result = $this->sut->map_product( $product );
+
+		$this->assertArrayHasKey( 'product_category', $result );
+		$this->assertEquals( 'Root Category > Child Category > Grandchild Category', $result['product_category'] );
+
+		$product->delete( true );
+		wp_delete_term( $grandchild_cat['term_id'], 'product_cat' );
+		wp_delete_term( $child_cat['term_id'], 'product_cat' );
+		wp_delete_term( $root_cat['term_id'], 'product_cat' );
+	}
+
+	/**
+	 * Test product_category selects deepest category when product has multiple categories
+	 */
+	public function test_map_product_category_selects_deepest(): void {
+		// Create two category hierarchies with different depths.
+		$shallow_cat = wp_insert_term( 'Shallow Category', 'product_cat' );
+		$this->assertIsArray( $shallow_cat );
+
+		$deep_root = wp_insert_term( 'Deep Root', 'product_cat' );
+		$this->assertIsArray( $deep_root );
+
+		$deep_child = wp_insert_term(
+			'Deep Child',
+			'product_cat',
+			[ 'parent' => $deep_root['term_id'] ]
+		);
+		$this->assertIsArray( $deep_child );
+
+		$deep_grandchild = wp_insert_term(
+			'Deep Grandchild',
+			'product_cat',
+			[ 'parent' => $deep_child['term_id'] ]
+		);
+		$this->assertIsArray( $deep_grandchild );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_category_ids( [ $shallow_cat['term_id'], $deep_grandchild['term_id'] ] );
+		$product->save();
+
+		$result = $this->sut->map_product( $product );
+
+		$this->assertArrayHasKey( 'product_category', $result );
+		// Should select the deepest hierarchy.
+		$this->assertEquals( 'Deep Root > Deep Child > Deep Grandchild', $result['product_category'] );
+
+		$product->delete( true );
+		wp_delete_term( $deep_grandchild['term_id'], 'product_cat' );
+		wp_delete_term( $deep_child['term_id'], 'product_cat' );
+		wp_delete_term( $deep_root['term_id'], 'product_cat' );
+		wp_delete_term( $shallow_cat['term_id'], 'product_cat' );
+	}
+
+	/**
+	 * Test product_category returns null when product has no categories
+	 */
+	public function test_map_product_category_null_when_no_categories(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		// Remove all categories including default 'Uncategorized'.
+		$category_ids = $product->get_category_ids();
+		if ( ! empty( $category_ids ) ) {
+			wp_remove_object_terms( $product->get_id(), $category_ids, 'product_cat' );
+		}
+
+		// Reload the product to ensure categories are cleared.
+		$product = wc_get_product( $product->get_id() );
+		$this->assertEmpty( $product->get_category_ids(), 'Product should have no categories' );
+
+		$result = $this->sut->map_product( $product );
+
+		// When no categories, product_category should not be in result.
+		$this->assertArrayNotHasKey( 'product_category', $result );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * Test product_category for variation uses parent product categories
+	 */
+	public function test_map_product_category_variation_uses_parent_categories(): void {
+		// Create category for parent product.
+		$parent_cat = wp_insert_term( 'Parent Category', 'product_cat' );
+		$this->assertIsArray( $parent_cat );
+
+		$child_cat = wp_insert_term(
+			'Child Category',
+			'product_cat',
+			[ 'parent' => $parent_cat['term_id'] ]
+		);
+		$this->assertIsArray( $child_cat );
+
+		// Create a different category for variation (should not be used).
+		$variation_cat = wp_insert_term( 'Variation Category', 'product_cat' );
+		$this->assertIsArray( $variation_cat );
+
+		// Create variable product with categories.
+		$variable_product = WC_Helper_Product::create_variation_product();
+		$variable_product->set_category_ids( [ $child_cat['term_id'] ] );
+		$variable_product->save();
+
+		$variations = $variable_product->get_children();
+		$this->assertNotEmpty( $variations );
+
+		$variation = wc_get_product( $variations[0] );
+		$this->assertNotNull( $variation );
+
+		// Set different category on variation (should be ignored).
+		$variation->set_category_ids( [ $variation_cat['term_id'] ] );
+		$variation->save();
+
+		$result = $this->sut->map_product( $variation );
+
+		$this->assertArrayHasKey( 'product_category', $result );
+		// Should use parent's categories, not variation's own categories.
+		$this->assertEquals( 'Parent Category > Child Category', $result['product_category'] );
+
+		$variable_product->delete( true );
+		wp_delete_term( $child_cat['term_id'], 'product_cat' );
+		wp_delete_term( $parent_cat['term_id'], 'product_cat' );
+		wp_delete_term( $variation_cat['term_id'], 'product_cat' );
+	}
+
+	/**
+	 * Test product_category for simple product uses its own categories
+	 */
+	public function test_map_product_category_simple_product_uses_own_categories(): void {
+		// Create category hierarchy.
+		$root_cat = wp_insert_term( 'Electronics', 'product_cat' );
+		$this->assertIsArray( $root_cat );
+
+		$child_cat = wp_insert_term(
+			'Laptops',
+			'product_cat',
+			[ 'parent' => $root_cat['term_id'] ]
+		);
+		$this->assertIsArray( $child_cat );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_category_ids( [ $child_cat['term_id'] ] );
+		$product->save();
+
+		$result = $this->sut->map_product( $product );
+
+		$this->assertArrayHasKey( 'product_category', $result );
+		$this->assertEquals( 'Electronics > Laptops', $result['product_category'] );
+
+		$product->delete( true );
+		wp_delete_term( $child_cat['term_id'], 'product_cat' );
+		wp_delete_term( $root_cat['term_id'], 'product_cat' );
+	}
+
+	/**
+	 * Test product_category with single level category (no parent)
+	 */
+	public function test_map_product_category_single_level(): void {
+		$category = wp_insert_term( 'Books', 'product_cat' );
+		$this->assertIsArray( $category );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_category_ids( [ $category['term_id'] ] );
+		$product->save();
+
+		$result = $this->sut->map_product( $product );
+
+		$this->assertArrayHasKey( 'product_category', $result );
+		$this->assertEquals( 'Books', $result['product_category'] );
+
+		$product->delete( true );
+		wp_delete_term( $category['term_id'], 'product_cat' );
 	}
 }


### PR DESCRIPTION
Fixes: WOOPTP-47

## Description


Improves the `ProductMapper` to correctly handle product categories for variations by using parent product data.

## Changes:

1. **Product category path improvements**: The `get_product_category()` method now uses parent product categories for variations and ensures correct hierarchical ordering with " > " separator. The method finds the deepest category, builds the path in correct order, and handles edge cases.

2. **Add tests for enable_search/enable_checkout with parent product**: Added new unit tests to verify that variations correctly use their parent product's meta settings for `enable_search` and `enable_checkout` fields.

## Testing instructions

Create a simple or variable product with nested categories, and confirm: 
- If nested category, the deepest one is selected.
- The category path uses the correct separator `>`. 

## Checklist

<!-- Mark completed items with an "x" -->

- [x] `npm run test:php` does not return errors.
- [x] `npm run lint:php` does not return errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved category hierarchy logic to determine the deepest category and build ordered hierarchical category paths for products and variations.
* **Bug Fixes**
  * Variations inherit search and checkout settings from their parent; handles cases with multiple/no categories correctly.
* **Tests**
  * Added extensive tests for category path construction, deepest-category selection, variation inheritance, single-level/no-category cases, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->