### PR TITLE
Add script to build prod zip file

### DIFF
--- a/.github/workflows/build-production-zip.yml
+++ b/.github/workflows/build-production-zip.yml
@@ -1,8 +1,7 @@
 name: Build Production Zip
 
 on:
-  # workflow_dispatch: # Disable temporarily to trigger in the current PR. 
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build-production-zip.yml
+++ b/.github/workflows/build-production-zip.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Upload production zip artifact
         uses: actions/upload-artifact@v4
         with:
-          name: openai-product-feed-production
-          path: build/OpenAI-Product-Feed.zip
+          name: OpenAI-Product-Feed
+          path: build/OpenAI-Product-Feed
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/build-production-zip.yml
+++ b/.github/workflows/build-production-zip.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Get Composer cache directory
         id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Composer dependencies
         uses: actions/cache@v4

--- a/.github/workflows/build-production-zip.yml
+++ b/.github/workflows/build-production-zip.yml
@@ -1,7 +1,8 @@
 name: Build Production Zip
 
 on:
-  workflow_dispatch:
+  # workflow_dispatch: # Disable temporarily to trigger in the current PR. 
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/build-production-zip.yml
+++ b/.github/workflows/build-production-zip.yml
@@ -1,0 +1,45 @@
+name: Build Production Zip
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Production Zip
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer:v2
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Make build script executable
+        run: chmod +x bin/build-prod-zip.sh
+
+      - name: Build production zip
+        run: ./bin/build-prod-zip.sh
+
+      - name: Upload production zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openai-product-feed-production
+          path: build/OpenAI-Product-Feed.zip
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/build-production-zip.yml
+++ b/.github/workflows/build-production-zip.yml
@@ -1,7 +1,8 @@
 name: Build Production Zip
 
 on:
-  workflow_dispatch:
+  # workflow_dispatch: # Disable temporarily to trigger in the current PR. 
+  pull_request:
 
 jobs:
   build:
@@ -42,4 +43,4 @@ jobs:
           name: openai-product-feed-production
           path: build/OpenAI-Product-Feed.zip
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 7

--- a/.github/workflows/build-production-zip.yml
+++ b/.github/workflows/build-production-zip.yml
@@ -30,16 +30,13 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      - name: Make build script executable
-        run: chmod +x bin/build-prod-zip.sh
-
       - name: Build production zip
         run: ./bin/build-prod-zip.sh
 
       - name: Upload production zip artifact
         uses: actions/upload-artifact@v4
         with:
-          name: OpenAI-Product-Feed
-          path: build/OpenAI-Product-Feed
+          name: woocommerce-product-feed-for-openai
+          path: build/woocommerce-product-feed-for-openai
           if-no-files-found: error
           retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ vendor/
 # Core test files
 tests/unit/woo
 
+# Build folder
+build/

--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@ A WooCommerce plugin that automatically generates and delivers product feeds to 
 
 ## What This Plugin Does
 
-**Connects your WooCommerce store to OpenAI's ChatGPT commerce platform** by automatically generating product feeds in the [required format](https://developers.openai.com/commerce/specs/feed) and delivering them via multiple channels.
-
-### Core Features
-
 - **ProductFeed generation abstraction** to support the large store.
 - **Complete OpenAI Specification Coverage** includes:
   - All required and optional fields supported
@@ -18,15 +14,9 @@ A WooCommerce plugin that automatically generates and delivers product feeds to 
 
 ## Quick Start
 
-### Installation
-
 1. **Build and get zip file** from the latest `trunk` branch by either:
    - Running `npm run build` in your local env
    - Running [Build Production Zip](https://github.com/woocommerce/OpenAI-Product-Feed/actions/workflows/build-production-zip.yml) workflow manually for your selected branch
 2. **Upload** the zip file via WordPress admin (Plugins > Add New > Upload Plugin) or extract to `/wp-content/plugins/`
 3. **Activate** the plugin through WordPress admin
 4. Go to **WooCommerce > Settings > Integrations > OpenAI** for OpenAI Product feed.
-
-### Basic Setup
-
-TBA 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A WooCommerce plugin that automatically generates and delivers product feeds to 
 1. **Build and get zip file** from the latest `trunk` branch by running: `npm run build`
 2. **Upload** the zip file via WordPress admin (Plugins > Add New > Upload Plugin) or extract to `/wp-content/plugins/`
 3. **Activate** the plugin through WordPress admin
-4. Go to **WooCommerce > Settings > Integrations > OpenAI**
+4. Go to **WooCommerce > Settings > Integrations > OpenAI** for OpenAI Product feed.
 
 ### Basic Setup
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ A WooCommerce plugin that automatically generates and delivers product feeds to 
 
 ### Installation
 
-1. **Build and get zip file** from the latest `trunk` branch by running: `npm run build`
+1. **Build and get zip file** from the latest `trunk` branch by either:
+   - Running `npm run build` in your local env
+   - Running [Build Production Zip](https://github.com/woocommerce/OpenAI-Product-Feed/actions/workflows/build-production-zip.yml) workflow manually for your selected branch
 2. **Upload** the zip file via WordPress admin (Plugins > Add New > Upload Plugin) or extract to `/wp-content/plugins/`
 3. **Activate** the plugin through WordPress admin
 4. Go to **WooCommerce > Settings > Integrations > OpenAI** for OpenAI Product feed.

--- a/README.md
+++ b/README.md
@@ -8,154 +8,23 @@ A WooCommerce plugin that automatically generates and delivers product feeds to 
 
 ### Core Features
 
-- **Complete OpenAI Specification Coverage** - All required and optional fields supported
-- **Real-time Updates** - Products sync within 30 seconds of changes
-- **Scheduled Delivery** - Automatic full feed updates every 15 minutes
-- **Per-Product Control** - Override global settings for individual products
-- **Feed Validation** - Built-in validation against OpenAI specifications
-- **Multiple Formats** - JSON, CSV, XML, TSV export options
-- **Secure API Access** - Admin-only REST endpoints for integration
+- **ProductFeed generation abstraction** to support the large store.
+- **Complete OpenAI Specification Coverage** includes:
+  - All required and optional fields supported
+  - Automatic full feed updates every 15 minutes
+  - Override global settings for individual products
+  - Built-in validation against OpenAI specifications
+- **Pos Catalog generation** 
 
 ## Quick Start
 
 ### Installation
 
-1. **Download** the latest release from GitHub Releases
+1. **Build and get zip file** from the latest `trunk` branch by running: `npm run build`
 2. **Upload** the zip file via WordPress admin (Plugins > Add New > Upload Plugin) or extract to `/wp-content/plugins/`
 3. **Activate** the plugin through WordPress admin
-4. Go to **WooCommerce > Settings > Integrations > ChatGPT**
+4. Go to **WooCommerce > Settings > Integrations > OpenAI**
 
 ### Basic Setup
 
-1. **Sign Up as OpenAI Merchant**
-   - Register at [ChatGPT Merchants](https://chatgpt.com/merchants)
-   - Verify your feed meets OpenAI specifications
-
-2. **Configure Integration Settings**
-   - Set your Feed Delivery URL (endpoint provided by OpenAI)
-   - Set Return Window (days)
-   - Store identity and policy settings are managed in WooCommerce core
-
-4. **Test Your Feed**
-   - Click "Preview Feed" to see generated data
-   - Check for validation errors
-   - Download sample feed files
-
-## How It Works
-
-### Product Data Mapping
-
-The plugin automatically maps your WooCommerce products to OpenAI's required format:
-
-| WooCommerce Data | OpenAI Field | Notes |
-|------------------|--------------|-------|
-| Product ID | `id` | Unique identifier |
-| Product Name | `title` | HTML stripped |
-| Description | `description` | Long or short description |
-| Stock Status | `availability` | `in_stock`, `out_of_stock`, `preorder` |
-| Weight | `weight` | With unit (kg, lbs, etc.) |
-| Images | `image_link`, `additional_image_link` | URLs |
-| Categories | `product_category` | Hierarchical path |
-| Attributes | `color`, `size`, `material`, etc. | Product attributes |
-
-### Feed Delivery Options
-
-**1. Push to OpenAI (Automatic)**
-- Scheduled: Every 15 minutes
-- Delta: 30 seconds after product changes
-- Manual: On-demand admin trigger
-
-**2. Pull via API (On-demand)**
-```
-GET /wp-json/wc/v3/openai-feed
-GET /wp-json/wc/v3/openai-feed?product_id=123
-```
-
-## Product Control
-
-### Global Settings
-Set store-wide defaults for:
-- **Search Visibility** - Whether products appear in ChatGPT search
-- **Checkout Enabled** - Whether products allow direct purchase
-- **Merchant Info** - Store details, policies, shipping
-
-### Per-Product Overrides
-Override global settings for specific products:
-- **Disable Search** - Exclude from ChatGPT search results
-- **Disable Checkout** - Remove direct purchase option
-- **Custom Fields** - Add product-specific data (GTIN, MPN, warnings, etc.)
-
-## Required vs Optional Fields
-
-### Required Fields (Always Included)
-- `enable_search`, `enable_checkout` - AI platform flags
-- `id`, `title`, `description`, `link` - Basic product info
-- `gtin`, `brand` - Product identifiers (with fallbacks)
-- `availability`, `inventory_quantity` - Stock info
-- `weight` - Product weight
-
-### Optional Fields (When Available)
-- **Product Details** - MPN, category, material, condition, age group
-- **Dimensions** - Length, width, height, combined dimensions
-- **Media** - Additional images, videos, 3D models
-- **Pricing** - Sale prices, promotional dates
-- **Variants** - Colors, sizes, gender targeting
-- **Shipping** - Methods, pickup options, SLA
-- **Compliance** - Warnings, age restrictions, Q&A
-
-## Access
-
-
-### Endpoints
-```http
-# Get complete feed
-GET /wp-json/wc/v3/openai-feed
-
-# Preview specific product
-GET /wp-json/wc/v3/openai-feed?product_id=123
-
-# Response format
-Content-Type: application/json
-[
-  {
-    "enable_search": "true",
-    "id": "123",
-    "title": "Product Name",
-    "availability": "in_stock",
-    "weight": "1.5 kg"
-    // ... all mapped fields
-  }
-]
-```
-
-## Validation & Troubleshooting
-
-### Feed Validation
-- **Automatic** - Validates before every delivery
-- **Manual** - Test via "Preview Feed" button
-- **Logged** - All validation errors logged to WooCommerce logs
-
-### Common Issues
-
-**Missing Required Fields**
-- GTIN → Add `_gtin` custom field or uses fallback `'MISSING'`
-- Brand → Add `pa_brand` attribute or uses fallback `'Generic'`
-
-**Validation Errors**
-- Check WooCommerce > Status > Logs (source: wpfoai)
-- Verify product data completeness
-- Test with single product preview
-
-**Delivery Issues**
-- Confirm endpoint URL and token
-- Check WooCommerce logs for HTTP errors
-- Verify network connectivity
-
-
-### Getting Help
-- Check WooCommerce > Status > Logs (source: wpfoai)
-- Use "Preview Feed" for testing individual products
-- Verify all required WooCommerce data is present
-
-### Logs Location
-WooCommerce > Status > Logs > Filter by source: `wpfoai`
+TBA 

--- a/bin/build-prod-zip.sh
+++ b/bin/build-prod-zip.sh
@@ -4,6 +4,9 @@
 # Exit on any error
 set -e
 
+# Plugin slug constant
+PLUGIN_SLUG="woocommerce-product-feed-for-openai"
+
 echo "======================================"
 echo "Building Production Zip"
 echo "======================================"
@@ -12,18 +15,18 @@ echo ""
 echo "Step 1: Creating build directory..."
 mkdir -p ./build
 
-if [ -d "./build/woocommerce-product-feed-for-openai" ]; then
-    echo "Removing existing woocommerce-product-feed-for-openai directory..."
-    rm -rf ./build/woocommerce-product-feed-for-openai
+if [ -d "./build/${PLUGIN_SLUG}" ]; then
+    echo "Removing existing ${PLUGIN_SLUG} directory..."
+    rm -rf ./build/${PLUGIN_SLUG}
 fi
 
 echo ""
-echo "Step 2: Creating woocommerce-product-feed-for-openai fresh directory..."
-mkdir -p ./build/woocommerce-product-feed-for-openai
+echo "Step 2: Creating ${PLUGIN_SLUG} fresh directory..."
+mkdir -p ./build/${PLUGIN_SLUG}
 
 echo ""
 echo "Step 3: Installing production dependencies..."
-COMPOSER_VENDOR_DIR=./build/woocommerce-product-feed-for-openai/vendor composer install --no-dev --optimize-autoloader
+COMPOSER_VENDOR_DIR=./build/${PLUGIN_SLUG}/vendor composer install --no-dev --optimize-autoloader
 
 echo ""
 echo "Step 4: Copying files and folders..."
@@ -33,17 +36,17 @@ FILES_TO_COPY=(
 )
 
 for file in "${FILES_TO_COPY[@]}"; do
-    cp -r "$file" ./build/woocommerce-product-feed-for-openai
+    cp -r "$file" ./build/${PLUGIN_SLUG}
 done
 
 echo ""
 echo "Step 5: Creating zip file..."
 cd ./build
-if [ -f "woocommerce-product-feed-for-openai.zip" ]; then
+if [ -f "${PLUGIN_SLUG}.zip" ]; then
     echo "Removing existing zip file..."
-    rm woocommerce-product-feed-for-openai.zip
+    rm ${PLUGIN_SLUG}.zip
 fi
-zip -r woocommerce-product-feed-for-openai.zip woocommerce-product-feed-for-openai
+zip -r ${PLUGIN_SLUG}.zip ${PLUGIN_SLUG}
 cd ..
 
 # Success message
@@ -52,13 +55,13 @@ echo "======================================"
 echo "✓ SUCCESS!"
 echo "======================================"
 echo "Production zip file created successfully!"
-echo "Location: ./build/woocommerce-product-feed-for-openai.zip"
-echo "Size: $(du -h ./build/woocommerce-product-feed-for-openai.zip | awk '{print $1}')"
+echo "Location: ./build/${PLUGIN_SLUG}.zip"
+echo "Size: $(du -h ./build/${PLUGIN_SLUG}.zip | awk '{print $1}')"
 
 # Cleanup build directory when not in CI environment
 if [ -z "$CI" ]; then
-    echo "Removing ./build/woocommerce-product-feed-for-openai directory"
-    rm -rf ./build/woocommerce-product-feed-for-openai
+    echo "Removing ./build/${PLUGIN_SLUG} directory"
+    rm -rf ./build/${PLUGIN_SLUG}
 fi
 
 echo "Done!"

--- a/bin/build-prod-zip.sh
+++ b/bin/build-prod-zip.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Build production zip file for OpenAI-Product-Feed
+# Exit on any error
+set -e
+
+echo "======================================"
+echo "Building Production Zip"
+echo "======================================"
+
+# Step 1: Run composer install
+echo ""
+echo "Step 1: Installing production dependencies..."
+composer install --no-dev --optimize-autoloader
+
+
+# Step 2: Create build directory if it doesn't exist
+echo ""
+echo "Step 2: Creating build directory..."
+mkdir -p ./build
+
+# Step 3: Clean up any existing OpenAI-Product-Feed directory in build
+if [ -d "./build/OpenAI-Product-Feed" ]; then
+    echo "Removing existing OpenAI-Product-Feed directory..."
+    rm -rf ./build/OpenAI-Product-Feed
+fi
+
+# Step 4: Create fresh OpenAI-Product-Feed directory
+echo ""
+echo "Step 3: Creating OpenAI-Product-Feed directory..."
+mkdir -p ./build/OpenAI-Product-Feed
+
+# Step 5: Copy files and folders
+echo ""
+echo "Step 4: Copying files and folders..."
+
+# Array of files/directories to copy
+FILES_TO_COPY=(
+    "./src"
+    "./vendor"
+    "./openai-product-feed-for-woo.php"
+    "./README.md"
+)
+
+for file in "${FILES_TO_COPY[@]}"; do
+    cp -r "$file" ./build/OpenAI-Product-Feed/
+done
+
+# Step 6: Create zip file
+echo ""
+echo "Step 5: Creating zip file..."
+cd ./build
+if [ -f "OpenAI-Product-Feed.zip" ]; then
+    echo "Removing existing zip file..."
+    rm OpenAI-Product-Feed.zip
+fi
+zip -r OpenAI-Product-Feed.zip OpenAI-Product-Feed
+cd ..
+
+# Success message
+echo ""
+echo "======================================"
+echo "✓ SUCCESS!"
+echo "======================================"
+echo "Production zip file created successfully!"
+echo "Location: ./build/OpenAI-Product-Feed.zip"
+echo "Size: $(du -h ./build/OpenAI-Product-Feed.zip | awk '{print $1}')"
+echo ""

--- a/bin/build-prod-zip.sh
+++ b/bin/build-prod-zip.sh
@@ -8,29 +8,23 @@ echo "======================================"
 echo "Building Production Zip"
 echo "======================================"
 
-# Step 1: Run composer install
 echo ""
 echo "Step 1: Installing production dependencies..."
 composer install --no-dev --optimize-autoloader
 
-
-# Step 2: Create build directory if it doesn't exist
 echo ""
 echo "Step 2: Creating build directory..."
 mkdir -p ./build
 
-# Step 3: Clean up any existing OpenAI-Product-Feed directory in build
 if [ -d "./build/OpenAI-Product-Feed" ]; then
     echo "Removing existing OpenAI-Product-Feed directory..."
     rm -rf ./build/OpenAI-Product-Feed
 fi
 
-# Step 4: Create fresh OpenAI-Product-Feed directory
 echo ""
-echo "Step 3: Creating OpenAI-Product-Feed directory..."
+echo "Step 3: Creating OpenAI-Product-Feed fresh directory..."
 mkdir -p ./build/OpenAI-Product-Feed
 
-# Step 5: Copy files and folders
 echo ""
 echo "Step 4: Copying files and folders..."
 
@@ -46,7 +40,6 @@ for file in "${FILES_TO_COPY[@]}"; do
     cp -r "$file" ./build/OpenAI-Product-Feed/
 done
 
-# Step 6: Create zip file
 echo ""
 echo "Step 5: Creating zip file..."
 cd ./build

--- a/bin/build-prod-zip.sh
+++ b/bin/build-prod-zip.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Build production zip file for OpenAI-Product-Feed
+# Build production zip file for woocommerce-product-feed-for-openai
 # Exit on any error
 set -e
 
@@ -9,45 +9,41 @@ echo "Building Production Zip"
 echo "======================================"
 
 echo ""
-echo "Step 1: Installing production dependencies..."
-composer install --no-dev --optimize-autoloader
-
-echo ""
-echo "Step 2: Creating build directory..."
+echo "Step 1: Creating build directory..."
 mkdir -p ./build
 
-if [ -d "./build/OpenAI-Product-Feed" ]; then
-    echo "Removing existing OpenAI-Product-Feed directory..."
-    rm -rf ./build/OpenAI-Product-Feed
+if [ -d "./build/woocommerce-product-feed-for-openai" ]; then
+    echo "Removing existing woocommerce-product-feed-for-openai directory..."
+    rm -rf ./build/woocommerce-product-feed-for-openai
 fi
 
 echo ""
-echo "Step 3: Creating OpenAI-Product-Feed fresh directory..."
-mkdir -p ./build/OpenAI-Product-Feed
+echo "Step 2: Creating woocommerce-product-feed-for-openai fresh directory..."
+mkdir -p ./build/woocommerce-product-feed-for-openai
+
+echo ""
+echo "Step 3: Installing production dependencies..."
+COMPOSER_VENDOR_DIR=./build/woocommerce-product-feed-for-openai/vendor composer install --no-dev --optimize-autoloader
 
 echo ""
 echo "Step 4: Copying files and folders..."
-
-# Array of files/directories to copy
 FILES_TO_COPY=(
     "./src"
-    "./vendor"
     "./openai-product-feed-for-woo.php"
-    "./README.md"
 )
 
 for file in "${FILES_TO_COPY[@]}"; do
-    cp -r "$file" ./build/OpenAI-Product-Feed/
+    cp -r "$file" ./build/woocommerce-product-feed-for-openai
 done
 
 echo ""
 echo "Step 5: Creating zip file..."
 cd ./build
-if [ -f "OpenAI-Product-Feed.zip" ]; then
+if [ -f "woocommerce-product-feed-for-openai.zip" ]; then
     echo "Removing existing zip file..."
-    rm OpenAI-Product-Feed.zip
+    rm woocommerce-product-feed-for-openai.zip
 fi
-zip -r OpenAI-Product-Feed.zip OpenAI-Product-Feed
+zip -r woocommerce-product-feed-for-openai.zip woocommerce-product-feed-for-openai
 cd ..
 
 # Success message
@@ -56,6 +52,13 @@ echo "======================================"
 echo "✓ SUCCESS!"
 echo "======================================"
 echo "Production zip file created successfully!"
-echo "Location: ./build/OpenAI-Product-Feed.zip"
-echo "Size: $(du -h ./build/OpenAI-Product-Feed.zip | awk '{print $1}')"
-echo ""
+echo "Location: ./build/woocommerce-product-feed-for-openai.zip"
+echo "Size: $(du -h ./build/woocommerce-product-feed-for-openai.zip | awk '{print $1}')"
+
+# Cleanup build directory when not in CI environment
+if [ -z "$CI" ]; then
+    echo "Removing ./build/woocommerce-product-feed-for-openai directory"
+    rm -rf ./build/woocommerce-product-feed-for-openai
+fi
+
+echo "Done!"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	},
 	"license": "GPL-2.0-or-later",
 	"scripts": {
-        "builld": "./bin/build-prod-zip.sh",
+        "build": "./bin/build-prod-zip.sh",
         "env:start": "wp-env start --update",
         "env:stop": "wp-env stop",
         "test:php": "./bin/checkout-woo-tests.sh && wp-env run --env-cwd='wp-content/plugins/woocommerce-product-feed-for-openai' tests-cli vendor/bin/phpunit -c phpunit.xml tests/unit/ProductFeed",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 	},
 	"license": "GPL-2.0-or-later",
 	"scripts": {
+        "builld": "./bin/build-prod-zip.sh",
         "env:start": "wp-env start --update",
         "env:stop": "wp-env stop",
         "test:php": "./bin/checkout-woo-tests.sh && wp-env run --env-cwd='wp-content/plugins/woocommerce-product-feed-for-openai' tests-cli vendor/bin/phpunit -c phpunit.xml tests/unit/ProductFeed",


### PR DESCRIPTION
Fixes: WOOPTP-55

## Description

<!-- Provide a brief description of the changes in this PR -->

- Add a new script to build the prod zip.
- Add GitHub workflow to build on the fly. 
- Update and trim down README.md. 

# Testing instructions

<!-- Provide testing instructions here -->

## Checklist

<!-- Mark completed items with an "x" -->

- [x] `npm run test:php` does not return errors.
- [x] `npm run lint:php` does not return errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified and restructured product documentation and Quick Start flow, replacing detailed setup and troubleshooting with a concise product-feed overview and WooCommerce settings reference.

* **Chores**
  * Added production packaging: local build script, CI workflow to produce a release ZIP artifact, and updated ignore rules to exclude build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->