### PR TITLE
[WIP] Improve DevHelpers handle for correct product types

### DIFF
--- a/src/Integrations/OpenAi/DevHelpers.php
+++ b/src/Integrations/OpenAi/DevHelpers.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\OpenAi;
 
+use Automattic\WooCommerce\Enums\ProductType;
 use WP_Post;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -108,7 +109,11 @@ class DevHelpers {
 		}
 
 		// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$product     = wc_get_product( $post->ID );
+		$product = wc_get_product( $post->ID );
+		if ( $product->is_type( ProductType::VARIABLE ) ) {
+			$variations = $product->get_available_variations( 'object' );
+			$product    = $variations[0];
+		}
 		$mapped_data = $this->mapper->map_product( $product );
 		$errors      = $this->validator->validate_entry( $mapped_data, $product );
 
@@ -146,8 +151,13 @@ class DevHelpers {
 		if ( self::COLUMN_ID !== $column ) {
 			return;
 		}
+		$product = wc_get_product( $post_id );
+		if ( $product->is_type( ProductType::VARIABLE ) ) {
+			// Get the first product variation to server the metabox.
+			$variations = $product->get_available_variations();
+			$product    = $variations[0];
+		}
 
-		$product     = wc_get_product( $post_id );
 		$mapped_data = $this->mapper->map_product( $product );
 		$errors      = $this->validator->validate_entry( $mapped_data, $product );
 


### PR DESCRIPTION
TODOS: 

- [ ] Make sure that only two product types variable and simple are handled. We can have a config for this after merging https://github.com/woocommerce/OpenAI-Product-Feed/pull/26. But I ideally, we would use `wc_get_products` with arg `includes` to get the single product we're want to validate. 
- [ ] All other product types are simply excluded. And give the message that: they're not supported. 
- [ ] For variable product, default is to display the first variation, but give the option to display multiple ones; for example, displaying links with variation product_id and then use it to parse the display.

## Description

<!-- Provide a brief description of the changes in this PR -->

# Testing instructions

<!-- Provide testing instructions here -->

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] `npm run test:php` does not return errors.
- [ ] `npm run lint:php` does not return errors.
