### PR TITLE
Ignore private products

### DIFF
--- a/src/Integrations/OpenAi/DevHelpers.php
+++ b/src/Integrations/OpenAi/DevHelpers.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\OpenAi;
 
+use Automattic\WooCommerce\Enums\ProductStatus;
 use WP_Post;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -151,7 +152,7 @@ class DevHelpers {
 		$mapped_data = $this->mapper->map_product( $product );
 		$errors      = $this->validator->validate_entry( $mapped_data, $product );
 
-		if ( 'false' === $mapped_data['enable_search'] ) {
+		if ( 'false' === $mapped_data['enable_search'] || ProductStatus::PRIVATE === $product->get_status() ) {
 			echo '<span class="dashicons dashicons-no-alt" title="Hidden from search"></span>';
 			return;
 		}

--- a/src/Integrations/OpenAi/FeedValidator.php
+++ b/src/Integrations/OpenAi/FeedValidator.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\OpenAi;
 
+use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\FeedValidatorInterface;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\OpenAi\FeedSchema;
 
@@ -69,6 +70,11 @@ final class FeedValidator implements FeedValidatorInterface {
 			)
 		) {
 			$issues[] = 'enable_checkout requires enable_search=true';
+		}
+
+		// Private products cannot appear in search results.
+		if ( ProductStatus::PRIVATE === $product->get_status() ) {
+			$issues[] = 'Private products will not appear in search results';
 		}
 
 		return $issues;

--- a/tests/unit/ProductFeed/Integrations/OpenAi/FeedValidatorTest.php
+++ b/tests/unit/ProductFeed/Integrations/OpenAi/FeedValidatorTest.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\OpenAi;
 
+use Automattic\WooCommerce\Enums\ProductStatus;
 use PHPUnit\Framework\MockObject\MockObject;
 
 
@@ -63,6 +64,20 @@ class FeedValidatorTest extends \WC_Unit_Test_Case {
 		$issues = $this->validator->validate_entry( $entry, $this->mock_product );
 
 		$this->assertEmpty( $issues, 'Valid entry should not have validation issues' );
+	}
+
+	public function test_validate_entry_with_private_product(): void {
+		$this->mock_product->method( 'get_status' )->willReturn( ProductStatus::PRIVATE );
+		$entry = [
+			'id'          => '123',
+			'title'       => 'Test Product',
+			'description' => 'Test Description',
+		];
+
+		$issues = $this->validator->validate_entry( $entry, $this->mock_product );
+
+		$this->assertNotEmpty( $issues );
+		$this->assertContains( 'Private products will not appear in search results', $issues );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Turns out that there wasn't much to do here, as private products do not appear in the results of `wc_get_products()`.

However, I still added a couple of details:

1. In `DevHelpers`, an 🅧 is added next to private products in the products table.
2. The `FeedValidator` adds a validation issue for private products. This way there is a safety net in case someone chooses to add private products to the query, but also an indication in the dev tool.

# Testing instructions

1. Setup a product to appear in the feed, and make sure it does. I used this command, modify it as you see fit:
`cat ${$(cli wp product-feed generate --integration=openai --silent)/\/var\/www\/html/\/Users\/rado\/Projects\/payments\/client\/docker\/wordpress} | jq .'[].title'`
2. Set the product to private.
3. The product page should indicate that private products will be ignored.
4. The products table should shown an `x` next to the product.
5. Most importantly, **the product should not appear in the feed anymore**.

## Checklist

<!-- Mark completed items with an "x" -->

- [x] `npm run test:php` does not return errors.
- [x] `npm run lint:php` does not return errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Private products are now consistently hidden from search results.
  * Added validation notification warning that private products won't appear in search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->