### PR TITLE
Generate feeds in temporary folders

### DIFF
--- a/src/Feed/FeedInterface.php
+++ b/src/Feed/FeedInterface.php
@@ -36,14 +36,14 @@ interface FeedInterface {
 	/**
 	 * Get the file path of the feed.
 	 *
-	 * @return string
+	 * @return string|null The path to the feed file, null if not ready.
 	 */
-	public function get_file_path(): string;
+	public function get_file_path(): ?string;
 
 	/**
 	 * Get the URL of the feed file.
 	 *
-	 * @return string|null The URL of the feed file, null if not completed.
+	 * @return string|null The URL of the feed file, null if not ready.
 	 */
 	public function get_file_url(): ?string;
 }

--- a/src/Storage/JsonFileFeed.php
+++ b/src/Storage/JsonFileFeed.php
@@ -190,17 +190,20 @@ class JsonFileFeed implements FeedInterface {
 			$tmp_path        = $this->file_path;
 			$this->file_path = $upload_dir['path'] . $this->file_name;
 			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-			if ( ! @rename( $tmp_path, $this->file_path ) ) {
+			if ( ! @copy( $tmp_path, $this->file_path ) ) {
 				throw new Exception(
 					esc_html(
 						sprintf(
-							/* translators: %s: directory path */
-							__( 'Unable to move feed file to upload directory: %s', 'woocommerce-product-feed-openai' ),
-							$this->file_path
+							/* translators: %1$s: file path, %2$s: error message */
+							__( 'Unable to move feed file %1$s to upload directory: %2$s', 'woocommerce-product-feed-openai' ),
+							$this->file_path,
+							error_get_last()
 						)
 					)
 				);
 			}
+
+			unlink( $tmp_path );
 		}
 
 		// Generate the URL.

--- a/src/Storage/JsonFileFeed.php
+++ b/src/Storage/JsonFileFeed.php
@@ -152,12 +152,36 @@ class JsonFileFeed implements FeedInterface {
 	 * End the feed.
 	 *
 	 * @return void
-	 * @throws Exception If the feed file cannot be moved to the upload directory.
 	 */
 	public function end(): void {
 		// Close the array and the file.
 		fwrite( $this->file_handle, ']' );
 		fclose( $this->file_handle );
+
+		// Indicate that we have a complete file.
+		$this->file_completed = true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_file_path(): ?string {
+		if ( ! $this->file_completed ) {
+			return null;
+		}
+
+		return $this->file_path;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws Exception If the feed file cannot be moved to the upload directory.
+	 */
+	public function get_file_url(): ?string {
+		if ( ! $this->file_completed ) {
+			return null;
+		}
 
 		$upload_dir = $this->get_upload_dir();
 
@@ -180,29 +204,6 @@ class JsonFileFeed implements FeedInterface {
 
 		// Generate the URL.
 		$this->file_url = $upload_dir['url'] . $this->file_name;
-
-		// Indicate that we have a complete file.
-		$this->file_completed = true;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function get_file_path(): ?string {
-		if ( ! $this->file_completed ) {
-			return null;
-		}
-
-		return $this->file_path;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function get_file_url(): ?string {
-		if ( ! $this->file_completed ) {
-			return null;
-		}
 
 		return $this->file_url;
 	}

--- a/src/Storage/JsonFileFeed.php
+++ b/src/Storage/JsonFileFeed.php
@@ -230,7 +230,7 @@ class JsonFileFeed implements FeedInterface {
 
 		// Try to create the directory if it does not exist.
 		if ( ! is_dir( $directory_path ) ) {
-			FileSystemUtil::mkdir_p_not_indexable( $directory_path );
+			FilesystemUtil::mkdir_p_not_indexable( $directory_path );
 		}
 
 		// `mkdir_p_not_indexable()` returns `void`, we have to check again.

--- a/src/Storage/JsonFileFeed.php
+++ b/src/Storage/JsonFileFeed.php
@@ -189,7 +189,8 @@ class JsonFileFeed implements FeedInterface {
 		if ( 0 === strpos( $this->file_path, get_temp_dir() ) ) {
 			$tmp_path        = $this->file_path;
 			$this->file_path = $upload_dir['path'] . $this->file_name;
-			if ( ! rename( $tmp_path, $this->file_path ) ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			if ( ! @rename( $tmp_path, $this->file_path ) ) {
 				throw new Exception(
 					esc_html(
 						sprintf(

--- a/src/Storage/JsonFileFeed.php
+++ b/src/Storage/JsonFileFeed.php
@@ -106,7 +106,7 @@ class JsonFileFeed implements FeedInterface {
 			wp_hash( $hash_data )
 		);
 
-		// Start by trying to use a temp direcotry to generate the feed.
+		// Start by trying to use a temp directory to generate the feed.
 		$this->file_path   = get_temp_dir() . DIRECTORY_SEPARATOR . $this->file_name;
 		$this->file_handle = fopen( $this->file_path, 'w' );
 		if ( false === $this->file_handle ) {
@@ -162,7 +162,7 @@ class JsonFileFeed implements FeedInterface {
 		$upload_dir = $this->get_upload_dir();
 
 		// Move the file to the upload directory if it is in temp.
-		if ( str_starts_with( $this->file_path, get_temp_dir() ) ) {
+		if ( 0 === strpos( $this->file_path, get_temp_dir() ) ) {
 			$tmp_path        = $this->file_path;
 			$this->file_path = $upload_dir['path'] . $this->file_name;
 			if ( ! rename( $tmp_path, $this->file_path ) ) {
@@ -211,7 +211,7 @@ class JsonFileFeed implements FeedInterface {
 	 * Get the upload directory for the feed.
 	 *
 	 * @return array {
-	 *     The upload directory for the feed.
+	 *     The upload directory for the feed. Both fields end with the right trailing slash.
 	 *
 	 *     @type string $path The path to the upload directory.
 	 *     @type string $url The URL to the upload directory.

--- a/src/Storage/JsonFileFeed.php
+++ b/src/Storage/JsonFileFeed.php
@@ -22,12 +22,28 @@ use Exception;
  * This class writes JSON directly to a file, entry by entry, without keeping everything in memory.
  */
 class JsonFileFeed implements FeedInterface {
+	public const UPLOAD_DIR = 'product-feeds';
+
 	/**
 	 * Indicates if there are previous entries in the feed.
 	 *
 	 * @var bool
 	 */
 	private $has_entries = false;
+
+	/**
+	 * The base name of the feed file.
+	 *
+	 * @var string
+	 */
+	private $base_name;
+
+	/**
+	 * The name of the feed file, no directory.
+	 *
+	 * @var string
+	 */
+	private $file_name;
 
 	/**
 	 * The path to the feed file.
@@ -42,13 +58,6 @@ class JsonFileFeed implements FeedInterface {
 	 * @var resource|null
 	 */
 	private $file_handle = null;
-
-	/**
-	 * The base name of the feed file.
-	 *
-	 * @var string
-	 */
-	private $base_name;
 
 	/**
 	 * Indicates if the feed file has been completed.
@@ -80,27 +89,6 @@ class JsonFileFeed implements FeedInterface {
 	 * @throws Exception If the feed directory cannot be created.
 	 */
 	public function start(): void {
-		$upload_dir = wp_upload_dir( null, true );
-		$directory  = $upload_dir['basedir'] . DIRECTORY_SEPARATOR . 'product-feeds' . DIRECTORY_SEPARATOR;
-
-		// Try to create the directory if it does not exist.
-		if ( ! is_dir( $directory ) ) {
-			FileSystemUtil::mkdir_p_not_indexable( $directory );
-		}
-
-		// `mkdir_p_not_indexable()` returns `void`, so we need to check again.
-		if ( ! is_dir( $directory ) ) {
-			throw new Exception(
-				esc_html(
-					sprintf(
-						/* translators: %s: directory path */
-						__( 'Unable to create feed directory: %s', 'woocommerce-product-feed-openai' ),
-						$directory
-					)
-				)
-			);
-		}
-
 		/**
 		 * Allows the current time to be overridden before a feed is stored.
 		 *
@@ -109,19 +97,24 @@ class JsonFileFeed implements FeedInterface {
 		 * @return int The current time.
 		 * @since 0.1.0
 		 */
-		$current_time = apply_filters( 'wpfoai_feed_time', time(), $this );
-		$hash_data    = $this->base_name . gmdate( 'r', $current_time );
-		$file_name    = sprintf(
+		$current_time    = apply_filters( 'wpfoai_feed_time', time(), $this );
+		$hash_data       = $this->base_name . gmdate( 'r', $current_time );
+		$this->file_name = sprintf(
 			'%s-%s-%s.json',
 			$this->base_name,
 			gmdate( 'Y-m-d', $current_time ),
 			wp_hash( $hash_data )
 		);
 
-		$this->file_path = $directory . $file_name;
-		$this->file_url  = $upload_dir['baseurl'] . '/product-feeds/' . $file_name;
-
+		// Start by trying to use a temp direcotry to generate the feed.
+		$this->file_path   = get_temp_dir() . DIRECTORY_SEPARATOR . $this->file_name;
 		$this->file_handle = fopen( $this->file_path, 'w' );
+		if ( false === $this->file_handle ) {
+			// Fall back to immediately using the upload directory for generation.
+			$upload_dir        = $this->get_upload_dir();
+			$this->file_path   = $upload_dir['path'] . $this->file_name;
+			$this->file_handle = fopen( $this->file_path, 'w' );
+		}
 
 		if ( false === $this->file_handle ) {
 			throw new Exception(
@@ -159,29 +152,52 @@ class JsonFileFeed implements FeedInterface {
 	 * End the feed.
 	 *
 	 * @return void
+	 * @throws Exception If the feed file cannot be moved to the upload directory.
 	 */
 	public function end(): void {
 		// Close the array and the file.
 		fwrite( $this->file_handle, ']' );
 		fclose( $this->file_handle );
 
+		$upload_dir = $this->get_upload_dir();
+
+		// Move the file to the upload directory if it is in temp.
+		if ( str_starts_with( $this->file_path, get_temp_dir() ) ) {
+			$tmp_path        = $this->file_path;
+			$this->file_path = $upload_dir['path'] . $this->file_name;
+			if ( ! rename( $tmp_path, $this->file_path ) ) {
+				throw new Exception(
+					esc_html(
+						sprintf(
+							/* translators: %s: directory path */
+							__( 'Unable to move feed file to upload directory: %s', 'woocommerce-product-feed-openai' ),
+							$this->file_path
+						)
+					)
+				);
+			}
+		}
+
+		// Generate the URL.
+		$this->file_url = $upload_dir['url'] . $this->file_name;
+
 		// Indicate that we have a complete file.
 		$this->file_completed = true;
 	}
 
 	/**
-	 * Get the path to the feed file.
-	 *
-	 * @return string The path to the feed file.
+	 * {@inheritDoc}
 	 */
-	public function get_file_path(): string {
+	public function get_file_path(): ?string {
+		if ( ! $this->file_completed ) {
+			return null;
+		}
+
 		return $this->file_path;
 	}
 
 	/**
-	 * Get the URL of the feed file.
-	 *
-	 * @return string|null The URL of the feed file, null if not completed.
+	 * {@inheritDoc}
 	 */
 	public function get_file_url(): ?string {
 		if ( ! $this->file_completed ) {
@@ -189,5 +205,54 @@ class JsonFileFeed implements FeedInterface {
 		}
 
 		return $this->file_url;
+	}
+
+	/**
+	 * Get the upload directory for the feed.
+	 *
+	 * @return array {
+	 *     The upload directory for the feed.
+	 *
+	 *     @type string $path The path to the upload directory.
+	 *     @type string $url The URL to the upload directory.
+	 * }
+	 * @throws Exception If the upload directory cannot be created.
+	 */
+	private function get_upload_dir(): array {
+		// Only generate everything once.
+		static $prepared;
+		if ( isset( $prepared ) ) {
+			return $prepared;
+		}
+
+		$upload_dir     = wp_upload_dir( null, true );
+		$directory_path = $upload_dir['basedir'] . DIRECTORY_SEPARATOR . self::UPLOAD_DIR . DIRECTORY_SEPARATOR;
+
+		// Try to create the directory if it does not exist.
+		if ( ! is_dir( $directory_path ) ) {
+			FileSystemUtil::mkdir_p_not_indexable( $directory_path );
+		}
+
+		// `mkdir_p_not_indexable()` returns `void`, we have to check again.
+		if ( ! is_dir( $directory_path ) ) {
+			throw new Exception(
+				esc_html(
+					sprintf(
+						/* translators: %s: directory path */
+						__( 'Unable to create feed directory: %s', 'woocommerce-product-feed-openai' ),
+						$directory_path
+					)
+				)
+			);
+		}
+
+		$directory_url = $upload_dir['baseurl'] . '/' . self::UPLOAD_DIR . '/';
+
+		// Follow the format, returned by `wp_upload_dir()`.
+		$prepared = [
+			'path' => $directory_path,
+			'url'  => $directory_url,
+		];
+		return $prepared;
 	}
 }

--- a/src/Storage/JsonFileFeed.php
+++ b/src/Storage/JsonFileFeed.php
@@ -74,6 +74,13 @@ class JsonFileFeed implements FeedInterface {
 	private $file_url = null;
 
 	/**
+	 * Indicates if the feed file is in a temp directory.
+	 *
+	 * @var bool
+	 */
+	private $is_temp_filepath = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $base_name The base name of the feed file.
@@ -114,6 +121,8 @@ class JsonFileFeed implements FeedInterface {
 			$upload_dir        = $this->get_upload_dir();
 			$this->file_path   = $upload_dir['path'] . $this->file_name;
 			$this->file_handle = fopen( $this->file_path, 'w' );
+		} else {
+			$this->is_temp_filepath = true;
 		}
 
 		if ( false === $this->file_handle ) {
@@ -186,7 +195,7 @@ class JsonFileFeed implements FeedInterface {
 		$upload_dir = $this->get_upload_dir();
 
 		// Move the file to the upload directory if it is in temp.
-		if ( 0 === strpos( $this->file_path, get_temp_dir() ) ) {
+		if ( $this->is_temp_filepath ) {
 			$tmp_path        = $this->file_path;
 			$this->file_path = $upload_dir['path'] . $this->file_name;
 			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
@@ -205,6 +214,8 @@ class JsonFileFeed implements FeedInterface {
 			}
 
 			unlink( $tmp_path );
+
+			$this->is_temp_filepath = false;
 		}
 
 		// Generate the URL.

--- a/src/Storage/JsonFileFeed.php
+++ b/src/Storage/JsonFileFeed.php
@@ -191,13 +191,14 @@ class JsonFileFeed implements FeedInterface {
 			$this->file_path = $upload_dir['path'] . $this->file_name;
 			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			if ( ! @copy( $tmp_path, $this->file_path ) ) {
+				$error = error_get_last();
 				throw new Exception(
 					esc_html(
 						sprintf(
 							/* translators: %1$s: file path, %2$s: error message */
 							__( 'Unable to move feed file %1$s to upload directory: %2$s', 'woocommerce-product-feed-openai' ),
 							$this->file_path,
-							error_get_last()
+							( esc_html( $error['message'] ) ?? 'Unknown error' )
 						)
 					)
 				);

--- a/tests/unit/ProductFeed/Storage/JsonFileFeedTest.php
+++ b/tests/unit/ProductFeed/Storage/JsonFileFeedTest.php
@@ -27,21 +27,19 @@ class JsonFileFeedTest extends ProductFeedTestCase {
 		$current_time = time();
 		add_filter( 'wpfoai_feed_time', fn() => $current_time );
 
-		// Make sure there is no directory and that it will be created.
-		$directory = $this->get_and_delete_dir();
-
 		$feed = new JsonFileFeed( 'test-feed' );
 		$feed->start();
 		$feed->end();
 
+		// The file should be in `/tmp` at first.
 		$path = $feed->get_file_path();
-		$this->assertStringContainsString( 'product-feeds', $path );
-		$this->assertStringContainsString( $directory, $path );
+		$this->assertStringContainsString( 'tmp', $path );
 		$this->assertStringContainsString( gmdate( 'Y-m-d', $current_time ), $path );
 		$this->assertStringContainsString( wp_hash( 'test-feed' . gmdate( 'r', $current_time ) ), $path );
 		$this->assertTrue( file_exists( $path ) );
 		$this->assertEquals( '[]', file_get_contents( $path ) );
 
+		// Once a URL is retrieved, the file will be moved to the uploads dir.
 		$url = $feed->get_file_url();
 		$this->assertNotNull( $url );
 		$this->assertStringEndsWith( '.json', (string) $url );
@@ -80,13 +78,6 @@ class JsonFileFeedTest extends ProductFeedTestCase {
 		$feed->end();
 	}
 
-	public function test_get_file_path_before_start_throws_type_error() {
-		$feed = new JsonFileFeed( 'test-feed' );
-		$this->expectException( \TypeError::class );
-		// Property is unset until start(); return type is string → TypeError.
-		$feed->get_file_path();
-	}
-
 	public function test_add_entry_before_start_throws_type_error() {
 		$feed = new JsonFileFeed( 'test-feed' );
 		$this->expectException( \TypeError::class );
@@ -99,7 +90,7 @@ class JsonFileFeedTest extends ProductFeedTestCase {
 		$feed->end();
 	}
 
-	public function test_start_throws_when_directory_cannot_be_created() {
+	public function test_get_file_url_throws_when_directory_cannot_be_created() {
 		// Ensure clean state then create a FILE where the directory should be.
 		$this->get_and_delete_dir();
 		$uploads_dir = wp_upload_dir()['basedir'];
@@ -110,8 +101,10 @@ class JsonFileFeedTest extends ProductFeedTestCase {
 
 		try {
 			$feed = new JsonFileFeed( 'test-feed' );
-			$this->expectException( \Exception::class );
 			$feed->start();
+			$feed->end();
+			$this->expectException( \Exception::class );
+			$feed->get_file_url();
 		} finally {
 			// Cleanup: remove blocking file.
 			if ( file_exists( $block_path ) && is_file( $block_path ) ) {

--- a/tests/unit/ProductFeed/Storage/JsonFileFeedTest.php
+++ b/tests/unit/ProductFeed/Storage/JsonFileFeedTest.php
@@ -33,15 +33,17 @@ class JsonFileFeedTest extends ProductFeedTestCase {
 
 		// The file should be in `/tmp` at first.
 		$path = $feed->get_file_path();
-		$this->assertStringContainsString( 'tmp', $path );
+		$this->assertStringStartsWith( get_temp_dir(), $path );
 		$this->assertStringContainsString( gmdate( 'Y-m-d', $current_time ), $path );
 		$this->assertStringContainsString( wp_hash( 'test-feed' . gmdate( 'r', $current_time ) ), $path );
 		$this->assertTrue( file_exists( $path ) );
 		$this->assertEquals( '[]', file_get_contents( $path ) );
 
 		// Once a URL is retrieved, the file will be moved to the uploads dir.
-		$url = $feed->get_file_url();
+		$url   = $feed->get_file_url();
+		$path2 = $feed->get_file_path();
 		$this->assertNotNull( $url );
+		$this->assertStringContainsString( 'uploads/product-feed', $path2 );
 		$this->assertStringEndsWith( '.json', (string) $url );
 		$this->assertStringContainsString( '/product-feeds/', (string) $url );
 	}


### PR DESCRIPTION
## Description

To better support various infrastructures, this PR alters where feeds are created and when they are moved:

- Instead of creating files straight in `wp-content`, try to do it within `get_temp_dir()` at first. This should allow installations where filesystem behavior is altered to still process the file normally.
- Only move the file to `wp-content` whenever a URL is requested. Otherwise it is assumed that the file will be pushed/streamed, and discarded.

# Testing instructions

As in other PRs:

1. Make sure that POS feed generation works by targeting `wp-json/wc/product-catalog/v1/create`.
2.Make sure the CLI command works without issues, incl. when pushing. Ex. `wp product-feed generate --integration=openai --push`.

## Checklist

<!-- Mark completed items with an "x" -->

- [x] `npm run test:php` does not return errors.
- [x] `npm run lint:php` does not return errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File path may be null until a feed is ready; requesting the URL now finalizes/moves the feed and returns a stable link.
  * Error messages for feed creation, writing, moving, or finalization have been clarified.

* **Chores**
  * Feeds are created in a temporary location and relocated to uploads only when published or the URL is requested.

* **Tests**
  * Tests updated to reflect temp-first creation and URL-triggered move to the uploads folder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->