### PR TITLE
Update the shipping fields

### DIFF
--- a/src/Integrations/OpenAi/ProductMapper.php
+++ b/src/Integrations/OpenAi/ProductMapper.php
@@ -1034,7 +1034,7 @@ final class ProductMapper implements ProductMapperInterface {
 				} elseif ( isset( $method->cost ) && is_numeric( $method->cost ) ) {
 					$price = $method->cost;
 				}
-				if ( empty( $price ) ) {
+				if ( '' === $price ) {
 					continue;
 				}
 

--- a/src/Integrations/OpenAi/ProductMapper.php
+++ b/src/Integrations/OpenAi/ProductMapper.php
@@ -1022,7 +1022,7 @@ final class ProductMapper implements ProductMapperInterface {
 
 			foreach ( $zone['shipping_methods'] as $method ) {
 				// Escape colons in method title.
-				$method_title = trim( str_replace( ':', '\:', $method->get_method_title() ), ':' );
+				$method_title = str_replace( ':', '\:', trim( $method->get_title(), ':' ) );
 
 				// Generate the price. Skip if none is found, even free.
 				$price = '';

--- a/src/Integrations/OpenAi/ProductMapper.php
+++ b/src/Integrations/OpenAi/ProductMapper.php
@@ -935,38 +935,27 @@ final class ProductMapper implements ProductMapperInterface {
 	}
 
 	/**
-	 * Get shipping data from WooCommerce zones (cached globally to prevent repeated queries)
+	 * Check if local pickup is available (cached to prevent repeated zone queries)
 	 *
-	 * @return string Shipping data string.
+	 * @return bool True if local pickup is available.
 	 */
-	private function get_shipping(): string {
-		if ( null !== self::$cached_shipping_data ) {
-			return self::$cached_shipping_data;
+	private function has_local_pickup(): bool {
+		if ( null !== self::$cached_has_local_pickup ) {
+			return self::$cached_has_local_pickup;
 		}
 
-		$shipping_data = [];
-		$zones         = $this->get_cached_shipping_zones();
-
+		$zones = $this->get_cached_shipping_zones();
 		foreach ( $zones as $zone ) {
-			$locations = $zone['zone_locations'];
-
 			foreach ( $zone['shipping_methods'] as $method ) {
-				$method_title = $method->get_method_title();
-				$price        = $this->get_shipping_price( $method );
-
-				foreach ( $locations as $location ) {
-					$shipping_string = $this->build_shipping_string( $location, $method_title, $price, $this->get_currency_code() );
-					if ( $shipping_string ) {
-						$shipping_data[] = $shipping_string;
-					}
+				if ( 'local_pickup' === $method->id ) {
+					self::$cached_has_local_pickup = true;
+					return self::$cached_has_local_pickup;
 				}
 			}
 		}
 
-		$shipping_data              = array_values( array_unique( $shipping_data ) );
-		self::$cached_shipping_data = empty( $shipping_data ) ? '' : implode( '; ', $shipping_data );
-
-		return self::$cached_shipping_data;
+		self::$cached_has_local_pickup = false;
+		return self::$cached_has_local_pickup;
 	}
 
 	/**
@@ -982,113 +971,104 @@ final class ProductMapper implements ProductMapperInterface {
 		// Get the main zones.
 		self::$cached_shipping_zones = \WC_Shipping_Zones::get_zones();
 
-		// There is the "Locations not covered by other zones" zone.
-		if ( empty( self::$cached_shipping_zones ) ) {
-			self::$cached_shipping_zones = [
-				WC_Shipping_Zones::get_zone( 0 )->get_shipping_methods(),
-			];
+		if ( ! empty( self::$cached_shipping_zones ) ) {
+			return self::$cached_shipping_zones;
 		}
 
+		// There is the "Locations not covered by other zones" zone.
+		self::$cached_shipping_zones = [
+			[
+				'zone_locations'   => [
+					(object) [
+						'type' => 'not_covered',
+						'code' => '',
+					],
+				],
+				'shipping_methods' => WC_Shipping_Zones::get_zone( 0 )->get_shipping_methods(),
+			],
+		];
 		return self::$cached_shipping_zones;
 	}
 
 	/**
-	 * Get shipping price from method.
-	 *
-	 * @param mixed $method Shipping method object.
-	 * @return string Shipping price.
-	 */
-	private function get_shipping_price( $method ): string {
-		if ( 'free_shipping' === $method->id ) {
-			return '0.00';
-		}
-
-		if ( isset( $method->settings['cost'] ) && is_numeric( $method->settings['cost'] ) ) {
-			return $method->settings['cost'];
-		}
-
-		return '';
-	}
-
-	/**
-	 * Build shipping string for location.
+	 * Get shipping data from WooCommerce zones (cached globally to prevent repeated queries).
 	 *
 	 * Format: country:region:service_class:price
-	 * Example: US:CA:Overnight:16.00 USD
-	 * Note: All 4 parts are required, even if region is empty (e.g., US::Flat rate:10.00 USD)
-	 * Note: Colons in service_class are escaped with backslash (e.g., Express\: Next Day)
+	 * Example: US:CA:Overnight:16.00 USD:BG:VAR:Flat rate:10.00 USD
+	 * Note: All 4 parts are required, even if region is empty (e.g., US::Flat rate:10.00 USD).
+	 * Note: Colons in service_class are escaped with backslash (e.g., Express\: Next Day).
+	 * Important: We are assuming that an empty string can be used for both country and region.
+	 *            This assumption might be completely wrong.
 	 *
-	 * @param mixed  $location Location object.
-	 * @param string $method_title Method title.
-	 * @param string $price Price value.
-	 * @param string $currency Currency code.
-	 * @return string|null Shipping string or null.
+	 * @return string Shipping data string.
 	 */
-	private function build_shipping_string( $location, string $method_title, string $price, string $currency ): ?string {
-		$country = '';
-		$region  = '';
-
-		switch ( $location->type ) {
-			case 'country':
-				$country = $location->code;
-				break;
-			case 'state':
-				list($country, $region) = array_pad( explode( ':', $location->code ), 2, '' );
-				break;
-			case 'continent':
-				$country = $location->code;
-				break;
-			default:
-				return null;
+	private function get_shipping(): string {
+		if ( null !== self::$cached_shipping_data ) {
+			return self::$cached_shipping_data;
 		}
 
-		// Skip if we don't have a price - can't provide meaningful shipping info without cost.
-		if ( '' === $price ) {
-			return null;
-		}
-
-		// Escape colons in method title to prevent breaking the delimiter structure.
-		$escaped_method_title = str_replace( ':', '\:', $method_title );
-
-		// OpenAI spec requires format: country:region:service_class:price
-		// All 4 parts must be present, even if region is empty.
-		$parts = [
-			trim( $country, ':' ),
-			trim( $region, ':' ),
-			trim( $escaped_method_title, ':' ),
-			sprintf( '%s %s', $price, $currency ),
-		];
-
-		return implode( ':', $parts );
-	}
-
-	/**
-	 * Check if local pickup is available (cached to prevent repeated zone queries)
-	 *
-	 * @return bool True if local pickup is available.
-	 */
-	private function has_local_pickup(): bool {
-		if ( null !== self::$cached_has_local_pickup ) {
-			return self::$cached_has_local_pickup;
-		}
-
-		if ( ! class_exists( 'WC_Shipping_Zones' ) ) {
-			self::$cached_has_local_pickup = false;
-			return self::$cached_has_local_pickup;
-		}
-
-		$zones = $this->get_cached_shipping_zones();
+		$shipping_data = [];
+		$zones         = $this->get_cached_shipping_zones();
+		$currency      = $this->get_currency_code();
 
 		foreach ( $zones as $zone ) {
+			$locations = $zone['zone_locations'];
+
 			foreach ( $zone['shipping_methods'] as $method ) {
-				if ( 'local_pickup' === $method->id ) {
-					self::$cached_has_local_pickup = true;
-					return self::$cached_has_local_pickup;
+				// Escape colons in method title.
+				$method_title = trim( str_replace( ':', '\:', $method->get_method_title() ), ':' );
+
+				// Generate the price. Skip if none is found, even free.
+				$price = '';
+				if ( 'free_shipping' === $method->id ) {
+					$price = '0.00';
+				} elseif ( isset( $method->cost ) && is_numeric( $method->cost ) ) {
+					$price = $method->cost;
+				}
+				if ( empty( $price ) ) {
+					continue;
+				}
+
+				foreach ( $locations as $location ) {
+					$country = null;
+					$region  = null;
+
+					switch ( $location->type ) {
+						case 'country':
+							$country = $location->code;
+							break;
+						case 'state':
+							list( $country, $region ) = array_pad( explode( ':', $location->code ), 2, '' );
+							break;
+						case 'continent':
+							$country = $location->code;
+							break;
+						case 'not_covered':
+							$country = '';
+							break;
+					}
+
+					if ( null === $country ) {
+						continue;
+					}
+
+					// OpenAI spec requires format: country:region:service_class:price
+					// All 4 parts must be present, even if region is empty.
+					$parts = [
+						trim( $country, ':' ),
+						trim( $region ?? '', ':' ),
+						$method_title,
+						sprintf( '%s %s', $price, $currency ),
+					];
+
+					$shipping_data[] = implode( ':', $parts );
 				}
 			}
 		}
 
-		self::$cached_has_local_pickup = false;
-		return self::$cached_has_local_pickup;
+		$shipping_data              = array_values( array_unique( $shipping_data ) );
+		self::$cached_shipping_data = empty( $shipping_data ) ? '' : implode( '; ', $shipping_data );
+
+		return self::$cached_shipping_data;
 	}
 }

--- a/src/Integrations/OpenAi/ProductMapper.php
+++ b/src/Integrations/OpenAi/ProductMapper.php
@@ -73,15 +73,6 @@ final class ProductMapper implements ProductMapperInterface {
 	}
 
 	/**
-	 * Resets data that is cached accross products.
-	 */
-	public function reset_cache() {
-		$this->cached_shipping_data    = null;
-		$this->cached_shipping_zones   = null;
-		$this->cached_has_local_pickup = null;
-	}
-
-	/**
 	 * Map WooCommerce product to feed row
 	 *
 	 * Main entry point for converting a WooCommerce product into OpenAI feed format.

--- a/src/Integrations/OpenAi/ProductMapper.php
+++ b/src/Integrations/OpenAi/ProductMapper.php
@@ -976,6 +976,12 @@ final class ProductMapper implements ProductMapperInterface {
 		}
 
 		// There is the "Locations not covered by other zones" zone.
+		$generic_zone = WC_Shipping_Zones::get_zone( 0 );
+		if ( ! $generic_zone || is_wp_error( $generic_zone ) ) {
+			$this->cached_shipping_zones = [];
+			return $this->cached_shipping_zones;
+		}
+
 		$this->cached_shipping_zones = [
 			[
 				'zone_locations'   => [
@@ -984,7 +990,7 @@ final class ProductMapper implements ProductMapperInterface {
 						'code' => '',
 					],
 				],
-				'shipping_methods' => WC_Shipping_Zones::get_zone( 0 )->get_shipping_methods(),
+				'shipping_methods' => $generic_zone->get_shipping_methods(),
 			],
 		];
 		return $this->cached_shipping_zones;

--- a/src/Integrations/OpenAi/ProductMapper.php
+++ b/src/Integrations/OpenAi/ProductMapper.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\ProductMapperInterface;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Utils\StringHelper;
 use RuntimeException;
+use WC_Shipping_Zones;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -943,11 +944,6 @@ final class ProductMapper implements ProductMapperInterface {
 			return self::$cached_shipping_data;
 		}
 
-		if ( ! class_exists( 'WC_Shipping_Zones' ) ) {
-			self::$cached_shipping_data = '';
-			return self::$cached_shipping_data;
-		}
-
 		$shipping_data = [];
 		$zones         = $this->get_cached_shipping_zones();
 
@@ -979,9 +975,20 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return array Shipping zones.
 	 */
 	private function get_cached_shipping_zones(): array {
-		if ( null === self::$cached_shipping_zones ) {
-			self::$cached_shipping_zones = \WC_Shipping_Zones::get_zones();
+		if ( null !== self::$cached_shipping_zones ) {
+			return self::$cached_shipping_zones;
 		}
+
+		// Get the main zones.
+		self::$cached_shipping_zones = \WC_Shipping_Zones::get_zones();
+
+		// There is the "Locations not covered by other zones" zone.
+		if ( empty( self::$cached_shipping_zones ) ) {
+			self::$cached_shipping_zones = [
+				WC_Shipping_Zones::get_zone( 0 )->get_shipping_methods(),
+			];
+		}
+
 		return self::$cached_shipping_zones;
 	}
 
@@ -1005,6 +1012,11 @@ final class ProductMapper implements ProductMapperInterface {
 
 	/**
 	 * Build shipping string for location.
+	 *
+	 * Format: country:region:service_class:price
+	 * Example: US:CA:Overnight:16.00 USD
+	 * Note: All 4 parts are required, even if region is empty (e.g., US::Flat rate:10.00 USD)
+	 * Note: Colons in service_class are escaped with backslash (e.g., Express\: Next Day)
 	 *
 	 * @param mixed  $location Location object.
 	 * @param string $method_title Method title.
@@ -1030,21 +1042,24 @@ final class ProductMapper implements ProductMapperInterface {
 				return null;
 		}
 
-		$parts = array_filter( [ $country, $region, $method_title ] );
-
-		if ( '' !== $price ) {
-			$parts[] = sprintf( '%s %s', $price, $currency );
+		// Skip if we don't have a price - can't provide meaningful shipping info without cost.
+		if ( '' === $price ) {
+			return null;
 		}
 
-		return implode(
-			':',
-			array_map(
-				function ( $part ) {
-					return trim( $part, ':' );
-				},
-				$parts
-			)
-		);
+		// Escape colons in method title to prevent breaking the delimiter structure.
+		$escaped_method_title = str_replace( ':', '\:', $method_title );
+
+		// OpenAI spec requires format: country:region:service_class:price
+		// All 4 parts must be present, even if region is empty.
+		$parts = [
+			trim( $country, ':' ),
+			trim( $region, ':' ),
+			trim( $escaped_method_title, ':' ),
+			sprintf( '%s %s', $price, $currency ),
+		];
+
+		return implode( ':', $parts );
 	}
 
 	/**

--- a/src/Integrations/OpenAi/ProductMapper.php
+++ b/src/Integrations/OpenAi/ProductMapper.php
@@ -46,21 +46,21 @@ final class ProductMapper implements ProductMapperInterface {
 	 *
 	 * @var string|null
 	 */
-	private static ?string $cached_shipping_data = null;
+	private ?string $cached_shipping_data = null;
 
 	/**
 	 * Cached shipping zones to prevent repeated API calls.
 	 *
 	 * @var array|null
 	 */
-	private static ?array $cached_shipping_zones = null;
+	private ?array $cached_shipping_zones = null;
 
 	/**
 	 * Cached local pickup availability flag.
 	 *
 	 * @var bool|null
 	 */
-	private static ?bool $cached_has_local_pickup = null;
+	private ?bool $cached_has_local_pickup = null;
 
 	/**
 	 * Dependency injector.
@@ -70,6 +70,15 @@ final class ProductMapper implements ProductMapperInterface {
 	public function init( Settings $settings ) {
 		$this->settings = $settings;
 		$this->schema   = FeedSchema::get_schema();
+	}
+
+	/**
+	 * Resets data that is cached accross products.
+	 */
+	public function reset_cache() {
+		$this->cached_shipping_data    = null;
+		$this->cached_shipping_zones   = null;
+		$this->cached_has_local_pickup = null;
 	}
 
 	/**
@@ -940,22 +949,22 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return bool True if local pickup is available.
 	 */
 	private function has_local_pickup(): bool {
-		if ( null !== self::$cached_has_local_pickup ) {
-			return self::$cached_has_local_pickup;
+		if ( null !== $this->cached_has_local_pickup ) {
+			return $this->cached_has_local_pickup;
 		}
 
 		$zones = $this->get_cached_shipping_zones();
 		foreach ( $zones as $zone ) {
 			foreach ( $zone['shipping_methods'] as $method ) {
 				if ( 'local_pickup' === $method->id ) {
-					self::$cached_has_local_pickup = true;
-					return self::$cached_has_local_pickup;
+					$this->cached_has_local_pickup = true;
+					return $this->cached_has_local_pickup;
 				}
 			}
 		}
 
-		self::$cached_has_local_pickup = false;
-		return self::$cached_has_local_pickup;
+		$this->cached_has_local_pickup = false;
+		return $this->cached_has_local_pickup;
 	}
 
 	/**
@@ -964,19 +973,19 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return array Shipping zones.
 	 */
 	private function get_cached_shipping_zones(): array {
-		if ( null !== self::$cached_shipping_zones ) {
-			return self::$cached_shipping_zones;
+		if ( null !== $this->cached_shipping_zones ) {
+			return $this->cached_shipping_zones;
 		}
 
 		// Get the main zones.
-		self::$cached_shipping_zones = \WC_Shipping_Zones::get_zones();
+		$this->cached_shipping_zones = \WC_Shipping_Zones::get_zones();
 
-		if ( ! empty( self::$cached_shipping_zones ) ) {
-			return self::$cached_shipping_zones;
+		if ( ! empty( $this->cached_shipping_zones ) ) {
+			return $this->cached_shipping_zones;
 		}
 
 		// There is the "Locations not covered by other zones" zone.
-		self::$cached_shipping_zones = [
+		$this->cached_shipping_zones = [
 			[
 				'zone_locations'   => [
 					(object) [
@@ -987,7 +996,7 @@ final class ProductMapper implements ProductMapperInterface {
 				'shipping_methods' => WC_Shipping_Zones::get_zone( 0 )->get_shipping_methods(),
 			],
 		];
-		return self::$cached_shipping_zones;
+		return $this->cached_shipping_zones;
 	}
 
 	/**
@@ -1003,8 +1012,8 @@ final class ProductMapper implements ProductMapperInterface {
 	 * @return string Shipping data string.
 	 */
 	private function get_shipping(): string {
-		if ( null !== self::$cached_shipping_data ) {
-			return self::$cached_shipping_data;
+		if ( null !== $this->cached_shipping_data ) {
+			return $this->cached_shipping_data;
 		}
 
 		$shipping_data = [];
@@ -1067,8 +1076,8 @@ final class ProductMapper implements ProductMapperInterface {
 		}
 
 		$shipping_data              = array_values( array_unique( $shipping_data ) );
-		self::$cached_shipping_data = empty( $shipping_data ) ? '' : implode( '; ', $shipping_data );
+		$this->cached_shipping_data = empty( $shipping_data ) ? '' : implode( '; ', $shipping_data );
 
-		return self::$cached_shipping_data;
+		return $this->cached_shipping_data;
 	}
 }

--- a/tests/unit/ProductFeed/Integrations/OpenAi/ProductMapperTest.php
+++ b/tests/unit/ProductFeed/Integrations/OpenAi/ProductMapperTest.php
@@ -5,14 +5,18 @@ namespace Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\OpenAi;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use Automattic\WooCommerce\Enums\ProductType;
+use Automattic\WooCommerce\ProductFeedForOpenAI\ProductFeedTestCase;
 use WC_Helper_Product;
+use WC_Shipping_Flat_Rate;
+use WC_Shipping_Zone;
+use WC_Shipping_Zones;
 
 /**
  * ProductMapper test class.
  *
  * Tests mapping of WooCommerce products to OpenAI feed format.
  */
-class ProductMapperTest extends \WC_Unit_Test_Case {
+class ProductMapperTest extends ProductFeedTestCase {
 	/**
 	 * System under test.
 	 *
@@ -1041,5 +1045,136 @@ class ProductMapperTest extends \WC_Unit_Test_Case {
 
 		$product->delete( true );
 		wp_delete_term( $category['term_id'], 'product_cat' );
+	}
+
+	public function provider_get_shipping(): array {
+		return [
+			'Single zone with flat rate'     => [
+				[
+					[
+						'name'             => 'California',
+						'location_type'    => 'state',
+						'location_code'    => 'US:CA',
+						'shipping_methods' => [ 'flat_rate' => [ 'cost' => '12' ] ],
+					],
+				],
+				'US:CA:Flat rate:12 USD',
+			],
+			'Single zone with free shipping' => [
+				[
+					[
+						'name'             => 'California',
+						'location_type'    => 'state',
+						'location_code'    => 'US:CA',
+						'shipping_methods' => [ 'free_shipping' => [] ],
+					],
+				],
+				'US:CA:Free shipping:0.00 USD',
+			],
+			'Multiple zones with different shipping methods, also countries' => [
+				[
+					[
+						'name'             => 'California',
+						'location_type'    => 'state',
+						'location_code'    => 'US:CA',
+						'shipping_methods' => [ 'flat_rate' => [ 'cost' => '12' ] ],
+					],
+					[
+						'name'             => 'Europe',
+						'location_type'    => 'country',
+						'location_code'    => 'BG',
+						'shipping_methods' => [ 'free_shipping' => [] ],
+					],
+				],
+				'US:CA:Flat rate:12 USD; BG::Free shipping:0.00 USD',
+			],
+			'Continent zone'                 => [
+				[
+					[
+						'name'             => 'Europe',
+						'location_type'    => 'continent',
+						'location_code'    => 'EU',
+						'shipping_methods' => [ 'flat_rate' => [ 'cost' => '13' ] ],
+					],
+				],
+				'EU::Flat rate:13 USD',
+			],
+			'No specific zones'              => [
+				[
+					[
+						'name'             => 'World',
+						'location_type'    => 'not_covered',
+						'location_code'    => '',
+						'shipping_methods' => [ 'flat_rate' => [ 'cost' => '14' ] ],
+						'id'               => 0,
+					],
+				],
+				'::Flat rate:14 USD',
+			],
+		];
+	}
+
+	/**
+	 * Test get_shipping.
+	 *
+	 * @param array  $zones Array of zones to create.
+	 * @param string $expected_string Expected shipping string.
+	 *
+	 * @dataProvider provider_get_shipping
+	 */
+	public function test_get_shipping( array $zones, string $expected_string ) {
+		foreach ( $zones as $zone ) {
+			$this->create_shipping_zone(
+				$zone['name'],
+				$zone['location_type'],
+				$zone['location_code'],
+				$zone['shipping_methods'],
+				$zone['id'] ?? null
+			);
+		}
+
+		$product = WC_Helper_Product::create_simple_product();
+		$result  = $this->sut->map_product( $product );
+
+		$this->assertArrayHasKey( 'shipping', $result );
+		$shipping = $result['shipping'];
+		$this->assertEquals( $expected_string, $shipping );
+	}
+
+	private function create_shipping_zone( string $name, string $location_type, string $location_code, $shipping_methods = [], $id = null ): WC_Shipping_Zone {
+		$instance_ids = [];
+
+		// Get the global zone for ID 0, or create a new one.
+		if ( 0 === $id ) {
+			$zone = WC_Shipping_Zones::get_zone( 0 );
+		} else {
+			$zone = new WC_Shipping_Zone();
+			$zone->set_zone_name( 'California' );
+		}
+
+		// Add locations based on string types.
+		$zone->add_location( $location_code, $location_type );
+		foreach ( $shipping_methods as $type => $settings ) {
+			$instance_ids[ $type ] = $zone->add_shipping_method( $type );
+		}
+		$zone->save();
+
+		// Add the necessary settings to all methods.
+		$methods = $zone->get_shipping_methods();
+		foreach ( $shipping_methods as $type => $settings ) {
+			// Load the shipping method.
+			$shipping_method = $methods[ $instance_ids[ $type ] ];
+
+			// Update instance settings.
+			$shipping_method->instance_settings = array_merge( $shipping_method->instance_settings, $settings );
+
+			// Save the settings.
+			update_option( $shipping_method->get_instance_option_key(), $shipping_method->instance_settings );
+
+			// Refresh the method.
+			$shipping_method->init_settings();
+		}
+
+		return $zone;
 	}
 }

--- a/tests/unit/ProductFeed/Integrations/OpenAi/ProductMapperTest.php
+++ b/tests/unit/ProductFeed/Integrations/OpenAi/ProductMapperTest.php
@@ -1049,7 +1049,7 @@ class ProductMapperTest extends ProductFeedTestCase {
 
 	public function provider_get_shipping(): array {
 		return [
-			'Single zone with flat rate'     => [
+			'Single zone with flat rate'                   => [
 				[
 					[
 						'name'             => 'California',
@@ -1060,7 +1060,7 @@ class ProductMapperTest extends ProductFeedTestCase {
 				],
 				'US:CA:Flat rate:12 USD',
 			],
-			'Single zone with free shipping' => [
+			'Single zone with free shipping'               => [
 				[
 					[
 						'name'             => 'California',
@@ -1088,7 +1088,7 @@ class ProductMapperTest extends ProductFeedTestCase {
 				],
 				'US:CA:Flat rate:12 USD; BG::Free shipping:0.00 USD',
 			],
-			'Continent zone'                 => [
+			'Continent zone'                               => [
 				[
 					[
 						'name'             => 'Europe',
@@ -1099,7 +1099,7 @@ class ProductMapperTest extends ProductFeedTestCase {
 				],
 				'EU::Flat rate:13 USD',
 			],
-			'No specific zones'              => [
+			'No specific zones'                            => [
 				[
 					[
 						'name'             => 'World',
@@ -1110,6 +1110,34 @@ class ProductMapperTest extends ProductFeedTestCase {
 					],
 				],
 				'::Flat rate:14 USD',
+			],
+			'Single zone with semicolons in method titles' => [
+				[
+					[
+						'name'             => 'Germany',
+						'location_type'    => 'country',
+						'location_code'    => 'DE',
+						'shipping_methods' => [
+							'flat_rate' => [
+								'cost'  => '15',
+								'title' => 'Flat rate:',
+							],
+						],
+					],
+					[
+						'name'             => 'Austria',
+						'location_type'    => 'country',
+						'location_code'    => 'AT',
+						'shipping_methods' => [
+							'flat_rate' => [
+								'cost'  => '18',
+								'title' => 'Flat rate: Austria',
+							],
+						],
+					],
+				],
+				// Germany's should be trimmed, Austria's escaped.
+				'DE::Flat rate:15 USD; AT::Flat rate\: Austria:18 USD',
 			],
 		];
 	}

--- a/tests/unit/ProductFeed/Integrations/OpenAi/ProductMapperTest.php
+++ b/tests/unit/ProductFeed/Integrations/OpenAi/ProductMapperTest.php
@@ -1149,7 +1149,7 @@ class ProductMapperTest extends ProductFeedTestCase {
 			$zone = WC_Shipping_Zones::get_zone( 0 );
 		} else {
 			$zone = new WC_Shipping_Zone();
-			$zone->set_zone_name( 'California' );
+			$zone->set_zone_name( $name );
 		}
 
 		// Add locations based on string types.


### PR DESCRIPTION
## Description

- Fix shipping for existing products.
- If no specific zones are defined, fall back to the fallback shipping zone ("Locations not covered by other zones").
- Rearrange methods for readability.
- Add tests.

Assumptions:

1. We can use the "Locations not covered by other zones" to fall back to display at least something.
2. **Important:** Empty countries/states can be provided. If that gets rejected by OpenAI, we can delete the necessary code to handle those or consider alternative approaches.

# Testing instructions

0. Use the dev helpers to display data on product edit screens to avoid constantly regenerating the field.
1. Add shipping zones. Experiment with multiple shipping zones, multiple shipping methods, no shipping zones, no shipping methods, etc.
2. Check the product to make sure that the output makes sense.

## Checklist

<!-- Mark completed items with an "x" -->

- [x] `npm run test:php` does not return errors.
- [x] `npm run lint:php` does not return errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shipping caching is now instance-scoped, fixing inconsistent shipping outputs and improving local-pickup detection.
  * Shipping assembly consolidated to produce consistent country:region:service:price entries, skip invalid entries, and return a sensible default when zones or methods are missing.

* **Tests**
  * Added unit tests covering multiple shipping zone and method scenarios to validate shipping-string output and local-pickup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->