### PR TITLE
Implement POS _fields filtering

### DIFF
--- a/src/Integrations/POSCatalog/ApiController.php
+++ b/src/Integrations/POSCatalog/ApiController.php
@@ -79,7 +79,14 @@ class ApiController {
 	public function generate_feed( WP_REST_Request $request ) {
 		$generator = $this->container->get( AsyncGenerator::class );
 		try {
-			$params   = [];
+			$params = [];
+			if ( null !== $request['_fields'] ) {
+				$params['_fields'] = $request['_fields'];
+
+				// We're hijacking the `_fields` parameter to use for the feed. Do not use it here.
+				unset( $request['_fields'] );
+			}
+
 			$response = $request->get_param( 'force' )
 				? $generator->force_regeneration( $params )
 				: $generator->get_status( $params );

--- a/src/Integrations/POSCatalog/ApiController.php
+++ b/src/Integrations/POSCatalog/ApiController.php
@@ -83,7 +83,13 @@ class ApiController {
 			if ( null !== $request['_fields'] ) {
 				$params['_fields'] = $request['_fields'];
 
-				// We're hijacking the `_fields` parameter to use for the feed. Do not use it here.
+				/**
+				 * We're "hijacking" the `_fields` parameter to use for the feed.
+				 *
+				 * This endpoint does not represent the typical REST API, as it does not
+				 * return the actual feed immediately, just its status. We will use
+				 * `_fields` to generate the feed, but we do not want to filter the result here.
+				 */
 				unset( $request['_fields'] );
 			}
 

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -155,6 +155,12 @@ final class AsyncGenerator {
 		$feed   = $this->integration->create_feed();
 		$walker = ProductWalker::from_integration( $this->integration, $feed );
 
+		// Add dynamic args to the mapper.
+		$args = $status['args'] ?? [];
+		if ( isset( $args['_fields'] ) && is_string( $args['_fields'] ) && ! empty( $args['_fields'] ) ) {
+			$this->integration->get_product_mapper()->set_fields( $args['_fields'] );
+		}
+
 		$walker->walk(
 			function ( WalkerProgress $progress ) use ( &$status, $option_key ) {
 				$status = $this->update_feed_progress( $status, $progress );

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Async Generator for feeds.
  */
-final class AsyncGenerator {
+class AsyncGenerator {
 	/**
 	 * The Action Scheduler action hook for the feed generation.
 	 *

--- a/src/Integrations/POSCatalog/POSIntegration.php
+++ b/src/Integrations/POSCatalog/POSIntegration.php
@@ -10,7 +10,6 @@ namespace Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\POSCatalog;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Core\DependencyManagement\Container;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\FeedInterface;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\FeedValidatorInterface;
-use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\ProductMapperInterface;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\IntegrationInterface;
 use Automattic\WooCommerce\ProductFeedForOpenAI\Storage\JsonFileFeed;
 
@@ -96,7 +95,7 @@ class POSIntegration implements IntegrationInterface {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function get_product_mapper(): ProductMapperInterface {
+	public function get_product_mapper(): ProductMapper {
 		return $this->container->get( ProductMapper::class );
 	}
 

--- a/src/Integrations/POSCatalog/ProductMapper.php
+++ b/src/Integrations/POSCatalog/ProductMapper.php
@@ -30,10 +30,15 @@ class ProductMapper implements ProductMapperInterface {
 	/**
 	 * Set fields to include in the product mapping.
 	 *
-	 * @param string $fields _Fields to include in the product mapping.
+	 * @param string|null $fields Fields to include in the product mapping.
 	 * @return void
 	 */
-	public function set_fields( string $fields ): void {
+	public function set_fields( ?string $fields = null ): void {
+		if ( null === $fields ) {
+			$this->fields = null;
+			return;
+		}
+
 		$this->fields = array_fill_keys(
 			array_map( 'trim', explode( ',', $fields ) ),
 			1

--- a/src/Integrations/POSCatalog/ProductMapper.php
+++ b/src/Integrations/POSCatalog/ProductMapper.php
@@ -21,6 +21,26 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class ProductMapper implements ProductMapperInterface {
 	/**
+	 * Fields to include in the product mapping.
+	 *
+	 * @var array|null Fields to include in the product mapping.
+	 */
+	private $fields = null;
+
+	/**
+	 * Set fields to include in the product mapping.
+	 *
+	 * @param string $fields _Fields to include in the product mapping.
+	 * @return void
+	 */
+	public function set_fields( string $fields ): void {
+		$this->fields = array_fill_keys(
+			array_map( 'trim', explode( ',', $fields ) ),
+			1
+		);
+	}
+
+	/**
 	 * Map WooCommerce product to catalog row
 	 *
 	 * @param WC_Product $product Product to map.
@@ -52,7 +72,12 @@ class ProductMapper implements ProductMapperInterface {
 		 * @param array      $row     Mapped product data.
 		 * @param WC_Product $product Product object.
 		 */
-		return apply_filters( 'oapfw_map_catalog_product', $row, $product );
+		$row = apply_filters( 'oapfw_map_catalog_product', $row, $product );
+
+		if ( null === $this->fields ) {
+			return $row;
+		}
+		return _rest_array_intersect_key_recursive( $row, $this->fields );
 	}
 
 	/**

--- a/src/Integrations/POSCatalog/ProductMapper.php
+++ b/src/Integrations/POSCatalog/ProductMapper.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\POSCatalog;
 
 use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\ProductMapperInterface;
 use WC_Product;
+use WP_REST_Response;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -23,9 +24,9 @@ class ProductMapper implements ProductMapperInterface {
 	/**
 	 * Fields to include in the product mapping.
 	 *
-	 * @var array|null Fields to include in the product mapping.
+	 * @var string|null Fields to include in the product mapping.
 	 */
-	private $fields = null;
+	private ?string $fields = null;
 
 	/**
 	 * Set fields to include in the product mapping.
@@ -34,15 +35,7 @@ class ProductMapper implements ProductMapperInterface {
 	 * @return void
 	 */
 	public function set_fields( ?string $fields = null ): void {
-		if ( null === $fields ) {
-			$this->fields = null;
-			return;
-		}
-
-		$this->fields = array_fill_keys(
-			array_map( 'trim', explode( ',', $fields ) ),
-			1
-		);
+		$this->fields = $fields;
 	}
 
 	/**
@@ -79,10 +72,24 @@ class ProductMapper implements ProductMapperInterface {
 		 */
 		$row = apply_filters( 'oapfw_map_catalog_product', $row, $product );
 
+		return $this->filter_product_fields( $row );
+	}
+
+	/**
+	 * Filter product fields based on the fields to include.
+	 *
+	 * @param array $row Product data array.
+	 * @return array Filtered product data array.
+	 */
+	protected function filter_product_fields( array $row ): array {
 		if ( null === $this->fields ) {
 			return $row;
 		}
-		return _rest_array_intersect_key_recursive( $row, $this->fields );
+
+		// Wrap the row in a response object to use it with core functions.
+		$_response = new WP_REST_Response( $row );
+		rest_filter_response_fields( $_response, null, [ '_fields' => $this->fields ] );
+		return $_response->get_data();
 	}
 
 	/**

--- a/tests/unit/ProductFeed/Integrations/POSCatalog/ApiControllerTest.php
+++ b/tests/unit/ProductFeed/Integrations/POSCatalog/ApiControllerTest.php
@@ -1,0 +1,83 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\POSCatalog;
+
+use Automattic\WooCommerce\ProductFeedForOpenAI\Core\DependencyManagement\Container;
+use Automattic\WooCommerce\ProductFeedForOpenAI\ProductFeedTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use WP_REST_Request;
+
+/**
+ * API controller test class.
+ */
+class ApiControllerTest extends ProductFeedTestCase {
+	/**
+	 * System under test.
+	 *
+	 * @var ApiController
+	 */
+	private ApiController $sut;
+
+	/**
+	 * Mock async generator.
+	 *
+	 * @var MockObject|AsyncGenerator
+	 */
+	private $mock_async_generator;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->mock_async_generator = $this->createMock( AsyncGenerator::class );
+		$this->test_container->replace_with_concrete( AsyncGenerator::class, $this->mock_async_generator );
+
+		$this->sut = $this->test_container->get( ApiController::class );
+	}
+
+	public function provider_generate_feed(): array {
+		return [
+			'No force-generation check, no fields'   => [ false, null ],
+			'No force-generation check, with fields' => [ false, 'id,name' ],
+			'Force generation, with fields'          => [ true, 'id,name' ],
+		];
+	}
+
+	/**
+	 * Test the generate_feed endpoint method.
+	 *
+	 * @dataProvider provider_generate_feed
+	 * @param bool        $force_regeneration Whether to force regeneration of the feed.
+	 * @param string|null $fields The fields to include in the feed.
+	 */
+	public function test_generate_feed( bool $force_regeneration, ?string $fields = null ) {
+		$request = new WP_REST_Request( 'POST', '/wc/product-catalog/v1/create' );
+
+		if ( $force_regeneration ) {
+			$request->set_param( 'force', true );
+		}
+		if ( $fields ) {
+			$request->set_param( '_fields', $fields );
+		}
+
+		$this->mock_async_generator->expects( $this->once() )
+			->method( $force_regeneration ? 'force_regeneration' : 'get_status' )
+			->with( $fields ? [ '_fields' => 'id,name' ] : [] )
+			->willReturn(
+				[
+					'action_id' => 6789,
+					'path'      => '/tmp/random_path.json',
+					'url'       => 'https://example.com/feed.json',
+				]
+			);
+
+		$response      = $this->sut->generate_feed( $request );
+		$response_data = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertArrayNotHasKey( 'action_id', $response_data );
+		$this->assertArrayNotHasKey( 'path', $response_data );
+		$this->assertArrayHasKey( 'url', $response_data );
+		$this->assertEquals( 'https://example.com/feed.json', $response_data['url'] );
+	}
+}

--- a/tests/unit/ProductFeed/Integrations/POSCatalog/ApiControllerTest.php
+++ b/tests/unit/ProductFeed/Integrations/POSCatalog/ApiControllerTest.php
@@ -62,7 +62,7 @@ class ApiControllerTest extends ProductFeedTestCase {
 
 		$this->mock_async_generator->expects( $this->once() )
 			->method( $force_regeneration ? 'force_regeneration' : 'get_status' )
-			->with( $fields ? [ '_fields' => 'id,name' ] : [] )
+			->with( $fields ? [ '_fields' => $fields ] : [] )
 			->willReturn(
 				[
 					'action_id' => 6789,

--- a/tests/unit/ProductFeed/Integrations/POSCatalog/AsyncGeneratorTest.php
+++ b/tests/unit/ProductFeed/Integrations/POSCatalog/AsyncGeneratorTest.php
@@ -1,0 +1,80 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\POSCatalog;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Automattic\WooCommerce\ProductFeedForOpenAI\ProductFeedTestCase;
+use WC_Helper_Product;
+
+/**
+ * Async generator test class.
+ */
+class AsyncGeneratorTest extends ProductFeedTestCase {
+	/**
+	 * System under test.
+	 *
+	 * @var AsyncGenerator
+	 */
+	private AsyncGenerator $sut;
+
+	/**
+	 * Mock integration.
+	 *
+	 * @var MockObject|POSIntegration
+	 */
+	private $mock_integration;
+
+	// Option key for tests.
+	private const OPTION_KEY = 'product_feed_async_test';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->mock_integration = $this->createMock( POSIntegration::class );
+		$this->test_container->replace_with_concrete( POSIntegration::class, $this->mock_integration );
+
+		$this->sut = $this->test_container->get( AsyncGenerator::class );
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		delete_option( self::OPTION_KEY );
+	}
+
+	public function test_feed_generation_action_forwards_args() {
+		// Make sure at least one product is present. We will not check it here.
+		WC_Helper_Product::create_simple_product();
+
+		// Set the initial option to indicate scheduled state.
+		$status = [
+			'state' => AsyncGenerator::STATE_SCHEDULED,
+			'args'  => [
+				'_fields' => 'id,name',
+			]
+		];
+		update_option( self::OPTION_KEY, $status );
+
+		// Expect the mapper to be called with the fields.
+		$mock_mapper = $this->createMock( ProductMapper::class );
+		$mock_mapper->expects( $this->once() )
+			->method( 'set_fields' )
+			->with( 'id,name' );
+		$mock_mapper->expects( $this->atLeast( 1 ) )
+			->method( 'map_product' )
+			->willReturn( [] );
+
+		// Replace the mapper with the integration.
+		$this->mock_integration->expects( $this->exactly( 2 ) )
+			->method( 'get_product_mapper' )
+			->willReturn( $mock_mapper );
+
+		// Trigger the action.
+		$this->sut->feed_generation_action( self::OPTION_KEY );
+
+		// Check the final status.
+		$updated_status = get_option( self::OPTION_KEY );
+		$this->assertEquals( AsyncGenerator::STATE_COMPLETED, $updated_status['state'] );
+	}
+}

--- a/tests/unit/ProductFeed/Integrations/POSCatalog/AsyncGeneratorTest.php
+++ b/tests/unit/ProductFeed/Integrations/POSCatalog/AsyncGeneratorTest.php
@@ -52,7 +52,7 @@ class AsyncGeneratorTest extends ProductFeedTestCase {
 			'state' => AsyncGenerator::STATE_SCHEDULED,
 			'args'  => [
 				'_fields' => 'id,name',
-			]
+			],
 		];
 		update_option( self::OPTION_KEY, $status );
 

--- a/tests/unit/ProductFeed/Integrations/POSCatalog/ProductMapperTest.php
+++ b/tests/unit/ProductFeed/Integrations/POSCatalog/ProductMapperTest.php
@@ -1,0 +1,74 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\POSCatalog;
+
+use Automattic\WooCommerce\ProductFeedForOpenAI\ProductFeedTestCase;
+use WC_Helper_Product;
+
+/**
+ * Product mapper test class.
+ */
+class ProductMapperTest2 extends ProductFeedTestCase {
+	/**
+	 * System under test.
+	 *
+	 * @var ProductMapper
+	 */
+	private ProductMapper $sut;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut = new ProductMapper();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		$this->sut->set_fields( null );
+	}
+
+	/**
+	 * Test mapping a simple product.
+	 */
+	public function test_map_product_simple_product(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_name( 'Test Product' );
+		$product->set_description( 'Test Description' );
+		$product->set_regular_price( '99.99' );
+
+		$result = $this->sut->map_product( $product );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertArrayHasKey( 'name', $result );
+		$this->assertArrayHasKey( 'description', $result );
+		$this->assertArrayHasKey( 'price', $result );
+		$this->assertArrayHasKey( 'downloadable', $result );
+		$this->assertArrayHasKey( 'parent_id', $result );
+		$this->assertArrayHasKey( 'images', $result );
+	}
+
+	/**
+	 * Test mapping a product with specific fields.
+	 */
+	public function test_map_product_with_fields(): void {
+		$this->sut->set_fields( 'id,name,description' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_name( 'Test Product' );
+		$product->set_description( 'Test Description' );
+		$product->set_regular_price( '99.99' );
+
+		$result = $this->sut->map_product( $product );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertArrayHasKey( 'name', $result );
+		$this->assertArrayHasKey( 'description', $result );
+		$this->assertArrayNotHasKey( 'price', $result );
+		$this->assertArrayNotHasKey( 'downloadable', $result );
+		$this->assertArrayNotHasKey( 'parent_id', $result );
+	}
+}

--- a/tests/unit/ProductFeed/Integrations/POSCatalog/ProductMapperTest.php
+++ b/tests/unit/ProductFeed/Integrations/POSCatalog/ProductMapperTest.php
@@ -9,7 +9,7 @@ use WC_Helper_Product;
 /**
  * Product mapper test class.
  */
-class ProductMapperTest2 extends ProductFeedTestCase {
+class ProductMapperTest extends ProductFeedTestCase {
 	/**
 	 * System under test.
 	 *

--- a/tests/unit/ProductFeed/ProductFeedTestCase.php
+++ b/tests/unit/ProductFeed/ProductFeedTestCase.php
@@ -82,6 +82,7 @@ class ProductFeedTestCase extends WC_Unit_Test_Case {
 
 		// Create a test container with the same initial cache.
 		$test_container = new TestContainer( $original_cache );
+		$container_property->setValue( $main_container, $test_container );
 		$plugin_property->setValue( $plugin_instance, $test_container );
 
 		return $test_container;


### PR DESCRIPTION
Fixes PAY-430

## Description

This PR builds on top of https://github.com/woocommerce/woocommerce-product-feed-for-openai/pull/26 and handles the internal `_fields` parameter of the REST API to filter which product fields to provide.

# Testing instructions

Follow the testing instructions from https://github.com/woocommerce/woocommerce-product-feed-for-openai/pull/26. You still need to generate API credentials and use them in CLI.

What needs to be done different here is to append fields to the command, and to inspect the generated JSON afterwards. Here is the updated cURL call:

```sh
curl -u "${wp_auth}" -X POST http://host/wp-json/wc/product-catalog/v1/create\?_fields\=id,name,price\&XDEBUG_SESSION\=XDEBUG_ECLIPSE
```

Then the JSON should only have the necessary fields:

```json

  {
    "id": 1972,
    "name": "Bookable Product",
    "price": 0
  },
  {
    "id": 1915,
    "name": "Extra Product",
    "price": 700
  },
  {
    "id": 1878,
    "name": "21 Simple",
    "price": 21
  },
  {
    "id": 1728,
    "name": "Pre-Order Product",
    "price": 30
  },
  {
    "id": 740,
    "name": "Free Product",
    "price": 0
  },
  {
    "id": 735,
    "name": "Variable product without variations",
    "price": 0
  },
  {
    "id": 732,
    "name": "Variable product without variations",
    "price": 0
  },
  {
    "id": 731,
    "name": "A variable subscription with sign-up fee - Blue",
    "price": 5
  },
  ...
]
```

## Checklist

- [x] `npm run test:php` does not return errors.
- [x] `npm run lint:php` does not return errors.

Note for tests: I have only added tests for the new functionality. The mapper and async generator of the POS feed need further testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * POS Catalog feeds support selective field filtering so feeds can include only requested product attributes.
  * Feed generation endpoint now accepts a fields parameter to control which attributes are returned; the async generation flow respects this setting.

* **Tests**
  * New unit tests covering feed generation, mapper field-filtering, and controller behavior to validate the new flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->