### PR TITLE
Use the products and variations controllers when mapping products

### DIFF
--- a/src/Integrations/POSCatalog/ApiController.php
+++ b/src/Integrations/POSCatalog/ApiController.php
@@ -49,10 +49,15 @@ class ApiController {
 				'callback'            => [ $this, 'generate_feed' ],
 				'permission_callback' => [ $this, 'is_authorized' ],
 				'args'                => [
-					'force' => [
+					'force'             => [
 						'type'        => 'boolean',
 						'default'     => false,
 						'description' => 'Force regeneration of the feed. NOOP if generation is in progress.',
+					],
+					'_variation_fields' => [
+						'type'        => 'string',
+						'description' => 'Comma-separated list of fields to include for variations.',
+						'required'    => false,
 					],
 				],
 			]
@@ -91,6 +96,9 @@ class ApiController {
 				 * `_fields` to generate the feed, but we do not want to filter the result here.
 				 */
 				unset( $request['_fields'] );
+			}
+			if ( null !== $request['_variation_fields'] ) {
+				$params['_variation_fields'] = $request['_variation_fields'];
 			}
 
 			$response = $request->get_param( 'force' )

--- a/src/Integrations/POSCatalog/ApiController.php
+++ b/src/Integrations/POSCatalog/ApiController.php
@@ -105,6 +105,14 @@ class ApiController {
 				? $generator->force_regeneration( $params )
 				: $generator->get_status( $params );
 
+			// Use the right datetime format.
+			if ( isset( $response['scheduled_at'] ) ) {
+				$response['scheduled_at'] = wc_rest_prepare_date_response( $response['scheduled_at'] );
+			}
+			if ( isset( $response['completed_at'] ) ) {
+				$response['completed_at'] = wc_rest_prepare_date_response( $response['completed_at'] );
+			}
+
 			// Remove sensitive data from the response.
 			if ( isset( $response['action_id'] ) ) {
 				unset( $response['action_id'] );

--- a/src/Integrations/POSCatalog/ApiController.php
+++ b/src/Integrations/POSCatalog/ApiController.php
@@ -54,6 +54,11 @@ class ApiController {
 						'default'     => false,
 						'description' => 'Force regeneration of the feed. NOOP if generation is in progress.',
 					],
+					'_product_fields' => [
+						'type'        => 'string',
+						'description' => 'Comma-separated list of fields to include for non-variable products.',
+						'required'    => false,
+					],
 					'_variation_fields' => [
 						'type'        => 'string',
 						'description' => 'Comma-separated list of fields to include for variations.',
@@ -85,17 +90,8 @@ class ApiController {
 		$generator = $this->container->get( AsyncGenerator::class );
 		try {
 			$params = [];
-			if ( null !== $request['_fields'] ) {
-				$params['_fields'] = $request['_fields'];
-
-				/**
-				 * We're "hijacking" the `_fields` parameter to use for the feed.
-				 *
-				 * This endpoint does not represent the typical REST API, as it does not
-				 * return the actual feed immediately, just its status. We will use
-				 * `_fields` to generate the feed, but we do not want to filter the result here.
-				 */
-				unset( $request['_fields'] );
+			if ( null !== $request['_product_fields'] ) {
+				$params['_product_fields'] = $request['_product_fields'];
 			}
 			if ( null !== $request['_variation_fields'] ) {
 				$params['_variation_fields'] = $request['_variation_fields'];

--- a/src/Integrations/POSCatalog/ApiController.php
+++ b/src/Integrations/POSCatalog/ApiController.php
@@ -54,7 +54,7 @@ class ApiController {
 						'default'     => false,
 						'description' => 'Force regeneration of the feed. NOOP if generation is in progress.',
 					],
-					'_product_fields' => [
+					'_product_fields'   => [
 						'type'        => 'string',
 						'description' => 'Comma-separated list of fields to include for non-variable products.',
 						'required'    => false,

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -158,10 +158,18 @@ class AsyncGenerator {
 
 		// Add dynamic args to the mapper.
 		$args = $status['args'] ?? [];
-		if ( isset( $args['_fields'] ) && is_string( $args['_fields'] ) && ! empty( $args['_fields'] ) ) {
-			$this->integration->get_product_mapper()->set_fields( $args['_fields'] );
+		if (
+			isset( $args['_product_fields'] )
+			&& is_string( $args['_product_fields'] ) &&
+			! empty( $args['_product_fields'] )
+		) {
+			$this->integration->get_product_mapper()->set_fields( $args['_product_fields'] );
 		}
-		if ( isset( $args['_variation_fields'] ) && is_string( $args['_variation_fields'] ) && ! empty( $args['_variation_fields'] ) ) {
+		if (
+			isset( $args['_variation_fields'] )
+			&& is_string( $args['_variation_fields'] ) &&
+			! empty( $args['_variation_fields'] )
+		) {
 			$this->integration->get_product_mapper()->set_variation_fields( $args['_variation_fields'] );
 		}
 

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -160,6 +160,9 @@ class AsyncGenerator {
 		if ( isset( $args['_fields'] ) && is_string( $args['_fields'] ) && ! empty( $args['_fields'] ) ) {
 			$this->integration->get_product_mapper()->set_fields( $args['_fields'] );
 		}
+		if ( isset( $args['_variation_fields'] ) && is_string( $args['_variation_fields'] ) && ! empty( $args['_variation_fields'] ) ) {
+			$this->integration->get_product_mapper()->set_variation_fields( $args['_variation_fields'] );
+		}
 
 		$walker->walk(
 			function ( WalkerProgress $progress ) use ( &$status, $option_key ) {

--- a/src/Integrations/POSCatalog/AsyncGenerator.php
+++ b/src/Integrations/POSCatalog/AsyncGenerator.php
@@ -104,6 +104,7 @@ class AsyncGenerator {
 
 		$status = [
 			'scheduled_at' => time(),
+			'completed_at' => null,
 			'state'        => self::STATE_SCHEDULED,
 			'progress'     => 0,
 			'processed'    => 0,
@@ -172,9 +173,10 @@ class AsyncGenerator {
 		);
 
 		// Store the final details.
-		$status['state'] = self::STATE_COMPLETED;
-		$status['url']   = $feed->get_file_url();
-		$status['path']  = $feed->get_file_path();
+		$status['state']        = self::STATE_COMPLETED;
+		$status['url']          = $feed->get_file_url();
+		$status['path']         = $feed->get_file_path();
+		$status['completed_at'] = time();
 		update_option( $option_key, $status );
 
 		// Schedule another action to delete the file after the expiry time.

--- a/src/Integrations/POSCatalog/ProductMapper.php
+++ b/src/Integrations/POSCatalog/ProductMapper.php
@@ -31,6 +31,13 @@ class ProductMapper implements ProductMapperInterface {
 	private ?string $fields = null;
 
 	/**
+	 * Fields to include in the variation mapping.
+	 *
+	 * @var string|null Fields to include in the variation mapping.
+	 */
+	private ?string $variation_fields = null;
+
+	/**
 	 * REST controller instance for products.
 	 *
 	 * @var WC_REST_Products_Controller|null
@@ -45,11 +52,18 @@ class ProductMapper implements ProductMapperInterface {
 	private ?WC_REST_Product_Variations_Controller $variations_controller = null;
 
 	/**
-	 * Cached REST request instance.
+	 * Cached REST request instance for products.
 	 *
 	 * @var WP_REST_Request|null
 	 */
-	private ?WP_REST_Request $rest_request = null;
+	private ?WP_REST_Request $products_request = null;
+
+	/**
+	 * Cached REST request instance for variations.
+	 *
+	 * @var WP_REST_Request|null
+	 */
+	private ?WP_REST_Request $variations_request = null;
 
 	/**
 	 * Initialize the mapper.
@@ -68,8 +82,19 @@ class ProductMapper implements ProductMapperInterface {
 	 * @return void
 	 */
 	public function set_fields( ?string $fields = null ): void {
-		$this->fields       = $fields;
-		$this->rest_request = null; // Invalidate the cached request.
+		$this->fields           = $fields;
+		$this->products_request = null; // Invalidate the cached request.
+	}
+
+	/**
+	 * Set fields to include in the variation mapping.
+	 *
+	 * @param string|null $fields Fields to include in the variation mapping.
+	 * @return void
+	 */
+	public function set_variation_fields( ?string $fields = null ): void {
+		$this->variation_fields   = $fields;
+		$this->variations_request = null; // Invalidate the cached request.
 	}
 
 	/**
@@ -79,15 +104,17 @@ class ProductMapper implements ProductMapperInterface {
 	 * @return array Mapped product data array.
 	 */
 	public function map_product( WC_Product $product ): array {
-		$controller = $product->is_type( 'variation' )
+		$is_variation = $product->is_type( 'variation' );
+		$controller   = $is_variation
 			? $this->variations_controller
 			: $this->products_controller;
 
-		$request  = $this->get_rest_request();
+		$request  = $is_variation ? $this->get_variations_request() : $this->get_products_request();
 		$response = $controller->prepare_object_for_response( $product, $request );
 
 		// Apply _fields filtering (normally done by REST server dispatch).
-		if ( null !== $this->fields ) {
+		$fields = $is_variation ? $this->variation_fields : $this->fields;
+		if ( null !== $fields ) {
 			$response = rest_filter_response_fields( $response, null, $request );
 		}
 
@@ -107,20 +134,38 @@ class ProductMapper implements ProductMapperInterface {
 	}
 
 	/**
-	 * Get the REST request instance.
+	 * Get the REST request instance for products.
 	 *
 	 * @return WP_REST_Request
 	 */
-	protected function get_rest_request(): WP_REST_Request {
-		if ( null === $this->rest_request ) {
-			$this->rest_request = new WP_REST_Request( 'GET' );
-			$this->rest_request->set_param( 'context', 'view' );
+	protected function get_products_request(): WP_REST_Request {
+		if ( null === $this->products_request ) {
+			$this->products_request = new WP_REST_Request( 'GET' );
+			$this->products_request->set_param( 'context', 'view' );
 
 			if ( null !== $this->fields ) {
-				$this->rest_request->set_param( '_fields', $this->fields );
+				$this->products_request->set_param( '_fields', $this->fields );
 			}
 		}
 
-		return $this->rest_request;
+		return $this->products_request;
+	}
+
+	/**
+	 * Get the REST request instance for variations.
+	 *
+	 * @return WP_REST_Request
+	 */
+	protected function get_variations_request(): WP_REST_Request {
+		if ( null === $this->variations_request ) {
+			$this->variations_request = new WP_REST_Request( 'GET' );
+			$this->variations_request->set_param( 'context', 'view' );
+
+			if ( null !== $this->variation_fields ) {
+				$this->variations_request->set_param( '_fields', $this->variation_fields );
+			}
+		}
+
+		return $this->variations_request;
 	}
 }

--- a/src/Integrations/POSCatalog/ProductMapper.php
+++ b/src/Integrations/POSCatalog/ProductMapper.php
@@ -91,7 +91,10 @@ class ProductMapper implements ProductMapperInterface {
 			$response = rest_filter_response_fields( $response, null, $request );
 		}
 
-		$row = $response->get_data();
+		$row = [
+			'type' => $product->get_type(),
+			'data' => $response->get_data(),
+		];
 
 		/**
 		 * Filter mapped catalog product data.

--- a/src/Integrations/POSCatalog/ProductMapper.php
+++ b/src/Integrations/POSCatalog/ProductMapper.php
@@ -9,7 +9,9 @@ namespace Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\POSCatalog;
 
 use Automattic\WooCommerce\ProductFeedForOpenAI\Feed\ProductMapperInterface;
 use WC_Product;
-use WP_REST_Response;
+use WC_REST_Products_Controller;
+use WC_REST_Product_Variations_Controller;
+use WP_REST_Request;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -18,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Product Mapper for the POS catalog.
  *
- * WIP class, copied from the `mobile/pos-catalog` branch.
+ * Uses WooCommerce REST API controllers to map product data.
  */
 class ProductMapper implements ProductMapperInterface {
 	/**
@@ -29,13 +31,45 @@ class ProductMapper implements ProductMapperInterface {
 	private ?string $fields = null;
 
 	/**
+	 * REST controller instance for products.
+	 *
+	 * @var WC_REST_Products_Controller|null
+	 */
+	private ?WC_REST_Products_Controller $products_controller = null;
+
+	/**
+	 * REST controller instance for variations.
+	 *
+	 * @var WC_REST_Product_Variations_Controller|null
+	 */
+	private ?WC_REST_Product_Variations_Controller $variations_controller = null;
+
+	/**
+	 * Cached REST request instance.
+	 *
+	 * @var WP_REST_Request|null
+	 */
+	private ?WP_REST_Request $rest_request = null;
+
+	/**
+	 * Initialize the mapper.
+	 *
+	 * @return void
+	 */
+	public function init(): void {
+		$this->products_controller   = new WC_REST_Products_Controller();
+		$this->variations_controller = new WC_REST_Product_Variations_Controller();
+	}
+
+	/**
 	 * Set fields to include in the product mapping.
 	 *
 	 * @param string|null $fields Fields to include in the product mapping.
 	 * @return void
 	 */
 	public function set_fields( ?string $fields = null ): void {
-		$this->fields = $fields;
+		$this->fields       = $fields;
+		$this->rest_request = null; // Invalidate the cached request.
 	}
 
 	/**
@@ -45,23 +79,12 @@ class ProductMapper implements ProductMapperInterface {
 	 * @return array Mapped product data array.
 	 */
 	public function map_product( WC_Product $product ): array {
-		$row = [
-			'id'                => $this->get_id( $product ),
-			'name'              => $this->get_name( $product ),
-			'type'              => $this->get_type( $product ),
-			'description'       => $this->get_description( $product ),
-			'short_description' => $this->get_short_description( $product ),
-			'sku'               => $this->get_sku( $product ),
-			'global_unique_id'  => $this->get_global_unique_id( $product ),
-			'price'             => $this->get_price( $product ),
-			'downloadable'      => $this->get_downloadable( $product ),
-			'parent_id'         => $this->get_parent_id( $product ),
-			'images'            => $this->get_images( $product ),
-			'attributes'        => $this->get_attributes( $product ),
-			'manage_stock'      => $this->get_manage_stock( $product ),
-			'stock_quantity'    => $this->get_stock_quantity( $product ),
-			'stock_status'      => $this->get_stock_status( $product ),
-		];
+		$controller = $product->is_type( 'variation' )
+			? $this->variations_controller
+			: $this->products_controller;
+
+		$response = $controller->prepare_object_for_response( $product, $this->get_rest_request() );
+		$row      = $response->get_data();
 
 		/**
 		 * Filter mapped catalog product data.
@@ -70,307 +93,24 @@ class ProductMapper implements ProductMapperInterface {
 		 * @param array      $row     Mapped product data.
 		 * @param WC_Product $product Product object.
 		 */
-		$row = apply_filters( 'oapfw_map_catalog_product', $row, $product );
-
-		return $this->filter_product_fields( $row );
+		return apply_filters( 'oapfw_map_catalog_product', $row, $product );
 	}
 
 	/**
-	 * Filter product fields based on the fields to include.
+	 * Get the REST request instance.
 	 *
-	 * @param array $row Product data array.
-	 * @return array Filtered product data array.
+	 * @return WP_REST_Request
 	 */
-	protected function filter_product_fields( array $row ): array {
-		if ( null === $this->fields ) {
-			return $row;
-		}
+	protected function get_rest_request(): WP_REST_Request {
+		if ( null === $this->rest_request ) {
+			$this->rest_request = new WP_REST_Request( 'GET' );
+			$this->rest_request->set_param( 'context', 'view' );
 
-		// Wrap the row in a response object to use it with core functions.
-		$_response = new WP_REST_Response( $row );
-		rest_filter_response_fields( $_response, null, [ '_fields' => $this->fields ] );
-		return $_response->get_data();
-	}
-
-	/**
-	 * Get product ID
-	 *
-	 * @param WC_Product $product Product object.
-	 * @return int Product ID.
-	 */
-	protected function get_id( WC_Product $product ): int {
-		return $product->get_id();
-	}
-
-	/**
-	 * Get product name
-	 *
-	 * @param WC_Product $product Product object.
-	 * @return string Product name.
-	 */
-	protected function get_name( WC_Product $product ): string {
-		return wp_strip_all_tags( $product->get_name() );
-	}
-
-	/**
-	 * Get product type
-	 *
-	 * @param WC_Product $product Product object.
-	 * @return string Product type.
-	 */
-	protected function get_type( WC_Product $product ): string {
-		return $product->get_type();
-	}
-
-	/**
-	 * Get product description
-	 *
-	 * @param WC_Product $product Product object.
-	 * @return string Product description.
-	 */
-	protected function get_description( WC_Product $product ): string {
-		$description = $product->get_description();
-		return $description ? wp_strip_all_tags( $description ) : '';
-	}
-
-	/**
-	 * Get product short description
-	 *
-	 * @param WC_Product $product Product object.
-	 * @return string Product short description.
-	 */
-	protected function get_short_description( WC_Product $product ): string {
-		$short_description = $product->get_short_description();
-		return $short_description ? wp_strip_all_tags( $short_description ) : '';
-	}
-
-	/**
-	 * Get product SKU
-	 *
-	 * @param WC_Product $product Product object.
-	 * @return string Product SKU.
-	 */
-	protected function get_sku( WC_Product $product ): string {
-		$sku = $product->get_sku();
-		return $sku ? $sku : '';
-	}
-
-	/**
-	 * Get product global unique ID
-	 *
-	 * @param WC_Product $product Product object.
-	 * @return string Global unique ID.
-	 */
-	protected function get_global_unique_id( WC_Product $product ): string {
-		return $product->get_global_unique_id();
-	}
-
-	/**
-	 * Get product price
-	 *
-	 * @param WC_Product $product Product object.
-	 * @return float Product price.
-	 */
-	protected function get_price( WC_Product $product ): float {
-		$price = $product->get_price();
-		return $price ? (float) $price : 0.0;
-	}
-
-	/**
-	 * Get product downloadable status
-	 *
-	 * @param WC_Product $product Product object.
-	 * @return bool True if downloadable.
-	 */
-	protected function get_downloadable( WC_Product $product ): bool {
-		return $product->is_downloadable();
-	}
-
-	/**
-	 * Get parent product ID
-	 *
-	 * @param WC_Product $product Product object.
-	 * @return int Parent product ID or 0.
-	 */
-	protected function get_parent_id( WC_Product $product ): int {
-		return $product->is_type( 'variation' ) ? $product->get_parent_id() : 0;
-	}
-
-	/**
-	 * Get product images
-	 * NOTE: from WC_REST_Products_V4_Controller.get_images in core.
-	 *
-	 * @param WC_Product $product Product object.
-	 * @return array Array of image objects matching WooCommerce API schema.
-	 */
-	protected function get_images( WC_Product $product ): array {
-		$images         = [];
-		$attachment_ids = [];
-
-		// Add featured image.
-		if ( $product->get_image_id() ) {
-			$attachment_ids[] = $product->get_image_id();
-		}
-
-		// Add gallery images.
-		$attachment_ids = array_merge( $attachment_ids, $product->get_gallery_image_ids() );
-
-		// Build image data.
-		foreach ( $attachment_ids as $attachment_id ) {
-			$attachment_post = get_post( $attachment_id );
-			if ( is_null( $attachment_post ) ) {
-				continue;
-			}
-
-			$attachment = wp_get_attachment_image_src( $attachment_id, 'full' );
-
-			if ( ! is_array( $attachment ) ) {
-				continue;
-			}
-			$thumbnail = wp_get_attachment_image_src( $attachment_id, 'woocommerce_thumbnail' );
-
-			$images[] = [
-				'id'                => (int) $attachment_id,
-				'date_created'      => wc_rest_prepare_date_response( $attachment_post->post_date, false ),
-				'date_created_gmt'  => wc_rest_prepare_date_response( strtotime( $attachment_post->post_date_gmt ) ),
-				'date_modified'     => wc_rest_prepare_date_response( $attachment_post->post_modified, false ),
-				'date_modified_gmt' => wc_rest_prepare_date_response( strtotime( $attachment_post->post_modified_gmt ) ),
-				'src'               => current( $attachment ),
-				'name'              => get_the_title( $attachment_id ),
-				'alt'               => get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
-				'srcset'            => (string) wp_get_attachment_image_srcset( $attachment_id, 'full' ),
-				'sizes'             => (string) wp_get_attachment_image_sizes( $attachment_id, 'full' ),
-				'thumbnail'         => is_array( $thumbnail ) ? current( $thumbnail ) : '',
-			];
-		}
-
-		return $images;
-	}
-
-	/**
-	 * Get product attributes
-	 * NOTE: from WC_REST_Products_V1_Controller in core.
-	 *
-	 * @param WC_Product $product Product object.
-	 * @return array Product attributes.
-	 */
-	protected function get_attributes( WC_Product $product ): array {
-		$attributes = [];
-
-		if ( $product->is_type( 'variation' ) ) {
-			// Variation attributes.
-			foreach ( $product->get_variation_attributes() as $attribute_name => $attribute ) {
-				$name = str_replace( 'attribute_', '', $attribute_name );
-
-				if ( ! $attribute ) {
-					continue;
-				}
-
-				// Taxonomy-based attributes are prefixed with `pa_`, otherwise simply `attribute_`.
-				if ( 0 === strpos( $attribute_name, 'attribute_pa_' ) ) {
-					$option_term  = get_term_by( 'slug', $attribute, $name );
-					$attributes[] = [
-						'id'     => wc_attribute_taxonomy_id_by_name( $name ),
-						'name'   => $this->get_attribute_taxonomy_label( $name ),
-						'option' => $option_term && ! is_wp_error( $option_term ) ? $option_term->name : $attribute,
-					];
-				} else {
-					$attributes[] = [
-						'id'     => 0,
-						'name'   => $name,
-						'option' => $attribute,
-					];
-				}
-			}
-		} else {
-			foreach ( $product->get_attributes() as $attribute ) {
-				if ( $attribute['is_taxonomy'] ) {
-					$attributes[] = [
-						'id'        => wc_attribute_taxonomy_id_by_name( $attribute['name'] ),
-						'name'      => $this->get_attribute_taxonomy_label( $attribute['name'] ),
-						'position'  => (int) $attribute['position'],
-						'visible'   => (bool) $attribute['is_visible'],
-						'variation' => (bool) $attribute['is_variation'],
-						'options'   => $this->get_attribute_options( $product->get_id(), $attribute ),
-					];
-				} else {
-					$attributes[] = [
-						'id'        => 0,
-						'name'      => $attribute['name'],
-						'position'  => (int) $attribute['position'],
-						'visible'   => (bool) $attribute['is_visible'],
-						'variation' => (bool) $attribute['is_variation'],
-						'options'   => $this->get_attribute_options( $product->get_id(), $attribute ),
-					];
-				}
+			if ( null !== $this->fields ) {
+				$this->rest_request->set_param( '_fields', $this->fields );
 			}
 		}
 
-		return $attributes;
-	}
-
-	/**
-	 * NOTE: from WC_REST_Products_V1_Controller in core.
-	 * Get attribute taxonomy label.
-	 *
-	 * @param  string $name Taxonomy name.
-	 * @return string
-	 */
-	protected function get_attribute_taxonomy_label( $name ) {
-		$tax = get_taxonomy( $name );
-		if ( ! $tax ) {
-			return '';
-		}
-
-		$labels = get_taxonomy_labels( $tax );
-		return $labels->singular_name;
-	}
-
-	/**
-	 * NOTE: from WC_REST_Products_V1_Controller in core.
-	 * Get attribute options.
-	 *
-	 * @param int   $product_id Product ID.
-	 * @param array $attribute  Attribute data.
-	 * @return array
-	 */
-	protected function get_attribute_options( $product_id, $attribute ) {
-		if ( isset( $attribute['is_taxonomy'] ) && $attribute['is_taxonomy'] ) {
-			return wc_get_product_terms( $product_id, $attribute['name'], [ 'fields' => 'names' ] );
-		} elseif ( isset( $attribute['value'] ) ) {
-			return array_map( 'trim', explode( '|', $attribute['value'] ) );
-		}
-
-		return [];
-	}
-
-	/**
-	 * Get manage stock status
-	 *
-	 * @param WC_Product $product Product object.
-	 * @return bool True if managing stock.
-	 */
-	protected function get_manage_stock( WC_Product $product ): bool {
-		return $product->get_manage_stock();
-	}
-
-	/**
-	 * Get stock quantity
-	 *
-	 * @param WC_Product $product Product object.
-	 * @return int|null Stock quantity or null.
-	 */
-	protected function get_stock_quantity( WC_Product $product ): ?int {
-		return $product->get_stock_quantity();
-	}
-
-	/**
-	 * Get stock status
-	 *
-	 * @param WC_Product $product Product object.
-	 * @return string Stock status.
-	 */
-	protected function get_stock_status( WC_Product $product ): string {
-		return $product->get_stock_status();
+		return $this->rest_request;
 	}
 }

--- a/src/Integrations/POSCatalog/ProductMapper.php
+++ b/src/Integrations/POSCatalog/ProductMapper.php
@@ -83,8 +83,15 @@ class ProductMapper implements ProductMapperInterface {
 			? $this->variations_controller
 			: $this->products_controller;
 
-		$response = $controller->prepare_object_for_response( $product, $this->get_rest_request() );
-		$row      = $response->get_data();
+		$request  = $this->get_rest_request();
+		$response = $controller->prepare_object_for_response( $product, $request );
+
+		// Apply _fields filtering (normally done by REST server dispatch).
+		if ( null !== $this->fields ) {
+			$response = rest_filter_response_fields( $response, null, $request );
+		}
+
+		$row = $response->get_data();
 
 		/**
 		 * Filter mapped catalog product data.

--- a/tests/unit/ProductFeed/Integrations/POSCatalog/ApiControllerTest.php
+++ b/tests/unit/ProductFeed/Integrations/POSCatalog/ApiControllerTest.php
@@ -57,12 +57,12 @@ class ApiControllerTest extends ProductFeedTestCase {
 			$request->set_param( 'force', true );
 		}
 		if ( $fields ) {
-			$request->set_param( '_fields', $fields );
+			$request->set_param( '_product_fields', $fields );
 		}
 
 		$this->mock_async_generator->expects( $this->once() )
 			->method( $force_regeneration ? 'force_regeneration' : 'get_status' )
-			->with( $fields ? [ '_fields' => $fields ] : [] )
+			->with( $fields ? [ '_product_fields' => $fields ] : [] )
 			->willReturn(
 				[
 					'action_id' => 6789,

--- a/tests/unit/ProductFeed/Integrations/POSCatalog/AsyncGeneratorTest.php
+++ b/tests/unit/ProductFeed/Integrations/POSCatalog/AsyncGeneratorTest.php
@@ -51,7 +51,8 @@ class AsyncGeneratorTest extends ProductFeedTestCase {
 		$status = [
 			'state' => AsyncGenerator::STATE_SCHEDULED,
 			'args'  => [
-				'_fields' => 'id,name',
+				'_product_fields'   => 'id,name',
+				'_variation_fields' => 'id,name,url',
 			],
 		];
 		update_option( self::OPTION_KEY, $status );
@@ -61,12 +62,15 @@ class AsyncGeneratorTest extends ProductFeedTestCase {
 		$mock_mapper->expects( $this->once() )
 			->method( 'set_fields' )
 			->with( 'id,name' );
+		$mock_mapper->expects( $this->once() )
+			->method( 'set_variation_fields' )
+			->with( 'id,name,url' );
 		$mock_mapper->expects( $this->atLeast( 1 ) )
 			->method( 'map_product' )
 			->willReturn( [] );
 
 		// Replace the mapper with the integration.
-		$this->mock_integration->expects( $this->exactly( 2 ) )
+		$this->mock_integration->expects( $this->atLeast( 1 ) )
 			->method( 'get_product_mapper' )
 			->willReturn( $mock_mapper );
 

--- a/tests/unit/ProductFeed/Integrations/POSCatalog/ProductMapperTest.php
+++ b/tests/unit/ProductFeed/Integrations/POSCatalog/ProductMapperTest.php
@@ -42,13 +42,15 @@ class ProductMapperTest extends ProductFeedTestCase {
 		$result = $this->sut->map_product( $product );
 
 		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'id', $result );
-		$this->assertArrayHasKey( 'name', $result );
-		$this->assertArrayHasKey( 'description', $result );
-		$this->assertArrayHasKey( 'price', $result );
-		$this->assertArrayHasKey( 'downloadable', $result );
-		$this->assertArrayHasKey( 'parent_id', $result );
-		$this->assertArrayHasKey( 'images', $result );
+		$this->assertArrayHasKey( 'type', $result );
+		$this->assertArrayHasKey( 'data', $result );
+		$this->assertArrayHasKey( 'id', $result['data'] );
+		$this->assertArrayHasKey( 'name', $result['data'] );
+		$this->assertArrayHasKey( 'description', $result['data'] );
+		$this->assertArrayHasKey( 'price', $result['data'] );
+		$this->assertArrayHasKey( 'downloadable', $result['data'] );
+		$this->assertArrayHasKey( 'parent_id', $result['data'] );
+		$this->assertArrayHasKey( 'images', $result['data'] );
 	}
 
 	/**
@@ -65,11 +67,12 @@ class ProductMapperTest extends ProductFeedTestCase {
 		$result = $this->sut->map_product( $product );
 
 		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'id', $result );
-		$this->assertArrayHasKey( 'name', $result );
-		$this->assertArrayHasKey( 'description', $result );
-		$this->assertArrayNotHasKey( 'price', $result );
-		$this->assertArrayNotHasKey( 'downloadable', $result );
-		$this->assertArrayNotHasKey( 'parent_id', $result );
+		$this->assertArrayHasKey( 'type', $result );
+		$this->assertArrayHasKey( 'data', $result );
+		$this->assertArrayHasKey( 'name', $result['data'] );
+		$this->assertArrayHasKey( 'description', $result['data'] );
+		$this->assertArrayNotHasKey( 'price', $result['data'] );
+		$this->assertArrayNotHasKey( 'downloadable', $result['data'] );
+		$this->assertArrayNotHasKey( 'parent_id', $result['data'] );
 	}
 }

--- a/tests/unit/ProductFeed/Integrations/POSCatalog/ProductMapperTest.php
+++ b/tests/unit/ProductFeed/Integrations/POSCatalog/ProductMapperTest.php
@@ -21,6 +21,7 @@ class ProductMapperTest extends ProductFeedTestCase {
 		parent::setUp();
 
 		$this->sut = new ProductMapper();
+		$this->sut->init(); // Could be done through DI, but there are no parameter dependencies.
 	}
 
 	public function tearDown(): void {


### PR DESCRIPTION
## Description

Previously, we had copied [some product fields](https://github.com/woocommerce/woocommerce-product-feed-for-openai/blob/5ec5b8f243c40cf3025dbdf1ad464330d3d2cfa1/src/Integrations/POSCatalog/ProductMapper.php#L47-L375) from WooCommerce core, adding un-necessary duplication.

This PR removes those implementations, instead replacing them with usage of the core `WC_REST_Products_Controller` and `WC_REST_Product_Variations_Controller` controllers.

- [x] Separate the `_fields` parameters for standard products and variations.
- [x] Ensure that the variations controller respects the parameter.

# Testing instructions

Request a POS catalog, and observe the result. It should mostly work as before.

Further instructions to be added upon changes.

## Checklist

<!-- Mark completed items with an "x" -->

- [x] `npm run test:php` does not return errors.
- [x] `npm run lint:php` does not return errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Feed generation endpoints now accept optional parameters to specify which product and variation fields to include in feeds, enabling more granular control over feed composition.
  * Feed responses now include completion timestamps, providing enhanced visibility into feed generation timing.

* **Bug Fixes**
  * Date fields in feed responses are now properly normalized for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->